### PR TITLE
Fix TRiD warning spam

### DIFF
--- a/probium/engines/cpp.py
+++ b/probium/engines/cpp.py
@@ -3,6 +3,17 @@ from __future__ import annotations
 from ..models import Candidate, Result
 from .base import EngineBase
 from ..registry import register
+import logging
+import mimetypes
+import magic
+
+logger = logging.getLogger(__name__)
+
+try:
+    _magic = magic.Magic(mime=True)
+except Exception as exc:  # pragma: no cover - lib setup
+    logger.warning("libmagic unavailable: %s", exc)
+    _magic = None
 
 @register
 class CppEngine(EngineBase):
@@ -10,6 +21,17 @@ class CppEngine(EngineBase):
     cost = 0.05
 
     def sniff(self, payload: bytes) -> Result:
+        if _magic is not None:
+            try:
+                mime = _magic.from_buffer(payload)
+            except Exception as exc:  # pragma: no cover
+                logger.warning("libmagic failed: %s", exc)
+            else:
+                if mime and ("c++" in mime or "cpp" in mime):
+                    ext = (mimetypes.guess_extension(mime) or "").lstrip(".") or "cpp"
+                    cand = Candidate(media_type=mime, extension=ext, confidence=0.95)
+                    return Result(candidates=[cand])
+
         try:
             text = payload.decode("utf-8", errors="ignore")
         except Exception:

--- a/probium/engines/magiclib.py
+++ b/probium/engines/magiclib.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+import logging
+import mimetypes
+import magic
+from ..models import Candidate, Result
+from .base import EngineBase
+from ..registry import register
+
+logger = logging.getLogger(__name__)
+
+@register
+class MagicLibEngine(EngineBase):
+    """Detect file types using libmagic."""
+
+    name = "libmagic"
+    cost = 0.02
+
+    def __init__(self) -> None:
+        super().__init__()
+        try:
+            self._magic = magic.Magic(mime=True)
+        except Exception as exc:  # pragma: no cover - library issues
+            logger.warning("libmagic unavailable: %s", exc)
+            self._magic = None
+
+    def sniff(self, payload: bytes) -> Result:
+        if self._magic is None:
+            return Result(candidates=[])
+        try:
+            mime = self._magic.from_buffer(payload)
+        except Exception as exc:  # pragma: no cover - rare
+            logger.warning("libmagic failed: %s", exc)
+            return Result(candidates=[])
+        if not mime:
+            return Result(candidates=[])
+        ext = (mimetypes.guess_extension(mime) or "").lstrip(".") or None
+        cand = Candidate(media_type=mime, extension=ext, confidence=0.9)
+        return Result(candidates=[cand])

--- a/probium/engines/php.py
+++ b/probium/engines/php.py
@@ -3,6 +3,17 @@ from __future__ import annotations
 from ..models import Candidate, Result
 from .base import EngineBase
 from ..registry import register
+import logging
+import mimetypes
+import magic
+
+logger = logging.getLogger(__name__)
+
+try:
+    _magic = magic.Magic(mime=True)
+except Exception as exc:  # pragma: no cover
+    logger.warning("libmagic unavailable: %s", exc)
+    _magic = None
 
 @register
 class PHPEngine(EngineBase):
@@ -10,6 +21,17 @@ class PHPEngine(EngineBase):
     cost = 0.05
 
     def sniff(self, payload: bytes) -> Result:
+        if _magic is not None:
+            try:
+                mime = _magic.from_buffer(payload)
+            except Exception as exc:  # pragma: no cover
+                logger.warning("libmagic failed: %s", exc)
+            else:
+                if mime and "php" in mime:
+                    ext = (mimetypes.guess_extension(mime) or "").lstrip(".") or "php"
+                    cand = Candidate(media_type=mime, extension=ext, confidence=0.95)
+                    return Result(candidates=[cand])
+
         try:
             text = payload.decode("utf-8", errors="ignore")
         except Exception:

--- a/probium/engines/powershell.py
+++ b/probium/engines/powershell.py
@@ -3,6 +3,17 @@ from __future__ import annotations
 from ..models import Candidate, Result
 from .base import EngineBase
 from ..registry import register
+import logging
+import mimetypes
+import magic
+
+logger = logging.getLogger(__name__)
+
+try:
+    _magic = magic.Magic(mime=True)
+except Exception as exc:  # pragma: no cover
+    logger.warning("libmagic unavailable: %s", exc)
+    _magic = None
 
 @register
 class PowerShellEngine(EngineBase):
@@ -10,6 +21,17 @@ class PowerShellEngine(EngineBase):
     cost = 0.05
 
     def sniff(self, payload: bytes) -> Result:
+        if _magic is not None:
+            try:
+                mime = _magic.from_buffer(payload)
+            except Exception as exc:  # pragma: no cover
+                logger.warning("libmagic failed: %s", exc)
+            else:
+                if mime and "powershell" in mime:
+                    ext = (mimetypes.guess_extension(mime) or "").lstrip(".") or "ps1"
+                    cand = Candidate(media_type=mime, extension=ext, confidence=0.95)
+                    return Result(candidates=[cand])
+
         try:
             text = payload.decode("utf-8", errors="ignore")
         except Exception:

--- a/probium/engines/signature.py
+++ b/probium/engines/signature.py
@@ -3,6 +3,17 @@ from __future__ import annotations
 from ..models import Candidate, Result
 from .base import EngineBase
 from ..registry import register
+import logging
+import mimetypes
+import magic
+
+logger = logging.getLogger(__name__)
+
+try:
+    _magic = magic.Magic(mime=True)
+except Exception as exc:  # pragma: no cover
+    logger.warning("libmagic unavailable: %s", exc)
+    _magic = None
 
 # quick byte signature lookups for common formats
 _SIGNATURES: dict[bytes, tuple[str, str]] = {
@@ -37,6 +48,17 @@ class SignatureEngine(EngineBase):
     cost = 0.05
 
     def sniff(self, payload: bytes) -> Result:
+        if _magic is not None:
+            try:
+                mime = _magic.from_buffer(payload)
+            except Exception as exc:  # pragma: no cover
+                logger.warning("libmagic failed: %s", exc)
+            else:
+                if mime:
+                    ext = (mimetypes.guess_extension(mime) or "").lstrip(".") or None
+                    cand = Candidate(media_type=mime, extension=ext, confidence=0.9)
+                    return Result(candidates=[cand])
+
         head = payload[:_MAX_SIG_LEN]
         for sig, (mime, ext) in _SIGNATURES.items():
             if head.startswith(sig):

--- a/probium/engines/swift.py
+++ b/probium/engines/swift.py
@@ -3,6 +3,17 @@ from __future__ import annotations
 from ..models import Candidate, Result
 from .base import EngineBase
 from ..registry import register
+import logging
+import mimetypes
+import magic
+
+logger = logging.getLogger(__name__)
+
+try:
+    _magic = magic.Magic(mime=True)
+except Exception as exc:  # pragma: no cover
+    logger.warning("libmagic unavailable: %s", exc)
+    _magic = None
 
 @register
 class SwiftEngine(EngineBase):
@@ -10,6 +21,17 @@ class SwiftEngine(EngineBase):
     cost = 0.05
 
     def sniff(self, payload: bytes) -> Result:
+        if _magic is not None:
+            try:
+                mime = _magic.from_buffer(payload)
+            except Exception as exc:  # pragma: no cover
+                logger.warning("libmagic failed: %s", exc)
+            else:
+                if mime and "swift" in mime:
+                    ext = (mimetypes.guess_extension(mime) or "").lstrip(".") or "swift"
+                    cand = Candidate(media_type=mime, extension=ext, confidence=0.95)
+                    return Result(candidates=[cand])
+
         try:
             text = payload.decode("utf-8", errors="ignore")
         except Exception:

--- a/probium/engines/toml.py
+++ b/probium/engines/toml.py
@@ -3,6 +3,17 @@ from __future__ import annotations
 from ..models import Candidate, Result
 from .base import EngineBase
 from ..registry import register
+import logging
+import mimetypes
+import magic
+
+logger = logging.getLogger(__name__)
+
+try:
+    _magic = magic.Magic(mime=True)
+except Exception as exc:  # pragma: no cover
+    logger.warning("libmagic unavailable: %s", exc)
+    _magic = None
 
 @register
 class TomlEngine(EngineBase):
@@ -10,6 +21,17 @@ class TomlEngine(EngineBase):
     cost = 0.05
 
     def sniff(self, payload: bytes) -> Result:
+        if _magic is not None:
+            try:
+                mime = _magic.from_buffer(payload)
+            except Exception as exc:  # pragma: no cover
+                logger.warning("libmagic failed: %s", exc)
+            else:
+                if mime and "toml" in mime:
+                    ext = (mimetypes.guess_extension(mime) or "").lstrip(".") or "toml"
+                    cand = Candidate(media_type=mime, extension=ext, confidence=0.95)
+                    return Result(candidates=[cand])
+
         try:
             text = payload.decode("utf-8", errors="ignore")
         except Exception:

--- a/probium/engines/trid.py
+++ b/probium/engines/trid.py
@@ -13,6 +13,8 @@ from ..registry import register
 logger = logging.getLogger(__name__)
 
 _TRID_CMD = shutil.which("trid")
+# set after the first missing-binary warning to avoid log spam
+_missing_warning_logged = False
 
 @register
 class TridEngine(EngineBase):
@@ -21,8 +23,11 @@ class TridEngine(EngineBase):
     cost = 5.0
 
     def sniff(self, payload: bytes) -> Result:
+        global _missing_warning_logged
         if _TRID_CMD is None:
-            logger.warning("trid command not found")
+            if not _missing_warning_logged:
+                logger.warning("trid command not found")
+                _missing_warning_logged = True
             return Result(candidates=[])
         with tempfile.NamedTemporaryFile(delete=False) as tmp:
             tmp.write(payload)

--- a/probium/engines/xml.py
+++ b/probium/engines/xml.py
@@ -2,6 +2,17 @@ from __future__ import annotations
 from ..models import Candidate, Result
 from .base import EngineBase
 from ..registry import register
+import logging
+import mimetypes
+import magic
+
+logger = logging.getLogger(__name__)
+
+try:
+    _magic = magic.Magic(mime=True)
+except Exception as exc:  # pragma: no cover
+    logger.warning("libmagic unavailable: %s", exc)
+    _magic = None
 
 @register
 class XMLEngine(EngineBase):
@@ -10,6 +21,17 @@ class XMLEngine(EngineBase):
     _MAGIC = [b'\xEF\xBB\xBF', b'\xFF\xFE', b'\xFE\xFF', b"<?xml"]
 
     def sniff(self, payload: bytes) -> Result:
+        if _magic is not None:
+            try:
+                mime = _magic.from_buffer(payload)
+            except Exception as exc:  # pragma: no cover
+                logger.warning("libmagic failed: %s", exc)
+            else:
+                if mime and "xml" in mime:
+                    ext = (mimetypes.guess_extension(mime) or "").lstrip(".") or "xml"
+                    cand = Candidate(media_type=mime, extension=ext, confidence=0.95)
+                    return Result(candidates=[cand])
+
         window = payload[:64]
         cand = []
 

--- a/probium/engines/zig.py
+++ b/probium/engines/zig.py
@@ -3,6 +3,17 @@ from __future__ import annotations
 from ..models import Candidate, Result
 from .base import EngineBase
 from ..registry import register
+import logging
+import mimetypes
+import magic
+
+logger = logging.getLogger(__name__)
+
+try:
+    _magic = magic.Magic(mime=True)
+except Exception as exc:  # pragma: no cover
+    logger.warning("libmagic unavailable: %s", exc)
+    _magic = None
 
 @register
 class ZigEngine(EngineBase):
@@ -10,6 +21,17 @@ class ZigEngine(EngineBase):
     cost = 0.05
 
     def sniff(self, payload: bytes) -> Result:
+        if _magic is not None:
+            try:
+                mime = _magic.from_buffer(payload)
+            except Exception as exc:  # pragma: no cover
+                logger.warning("libmagic failed: %s", exc)
+            else:
+                if mime and "zig" in mime:
+                    ext = (mimetypes.guess_extension(mime) or "").lstrip(".") or "zig"
+                    cand = Candidate(media_type=mime, extension=ext, confidence=0.95)
+                    return Result(candidates=[cand])
+
         try:
             text = payload.decode("utf-8", errors="ignore")
         except Exception:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ dependencies = [
   "pydantic>=2.7",
   "cachetools>=5.3",
   "platformdirs>=4.2",
-  "olefile>=0.46"
+  "olefile>=0.46",
+  "python-magic>=0.4.27"
 ]
 authors = [{ name = "frankoceanluvr26"}]
 [build-system]


### PR DESCRIPTION
## Summary
- quiet repeated warnings from the TRiD engine when `trid` is unavailable
- add new libmagic-based engine for byte-signature detection
- declare python-magic dependency
- switch first engines to use libmagic before heuristics

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685968e0528c8331a573b408f310df5a