### PR TITLE
Implement magic signature detection

### DIFF
--- a/probium/__init__.py
+++ b/probium/__init__.py
@@ -1,6 +1,7 @@
 from importlib.metadata import entry_points, version
 from typing import TYPE_CHECKING
 from .core import detect, scan_dir, list_engines
+from .magic_service import detect_magic
 from .trid_multi import detect_with_trid
 from .exceptions import EngineFailure, FastbackError, UnsupportedType
 from .registry import register
@@ -13,6 +14,7 @@ __all__ = [
     "UnsupportedType",
     "EngineFailure",
     "detect_with_trid",
+    "detect_magic",
 ]
 try:
     from .core import detect_async

--- a/probium/magic_service.py
+++ b/probium/magic_service.py
@@ -1,0 +1,47 @@
+"""High performance detection using custom magic numbers."""
+from __future__ import annotations
+from pathlib import Path
+
+from .models import Result
+from .core import detect, _load_bytes
+from .registry import get_instance
+
+# tuples of (signature bytes, offset, engine name)
+MAGIC_SIGNATURES: list[tuple[bytes, int, str]] = [
+    (b"MZ", 0, "exe"),
+    (b"%PDF", 0, "pdf"),
+    (b"\x89PNG\r\n\x1a\n", 0, "png"),
+    (b"GIF87a", 0, "image"),
+    (b"GIF89a", 0, "image"),
+    (b"\xff\xd8\xff", 0, "image"),
+    (b"ftyp", 4, "mp4"),
+    (b"ID3", 0, "mp3"),
+    (b"OggS", 0, "ogg"),
+    (b"fLaC", 0, "flac"),
+    (b"RIFF", 0, "wav"),
+    (b"\x1f\x8b", 0, "gzip"),
+    (b"BZh", 0, "bzip2"),
+    (b"7z\xBC\xAF\x27\x1C", 0, "7z"),
+    (b"\xFD7zXZ\x00", 0, "xz"),
+    (b"Rar!", 0, "rar"),
+    (b"BM", 0, "bmp"),
+    (b"\x00\x00\x01\x00", 0, "ico"),
+    (b"SQLite format 3\x00", 0, "sqlite"),
+    (b"\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1", 0, "legacyoffice"),
+    (b"PK\x03\x04", 0, "zipoffice"),
+    (b"ustar", 257, "tar"),
+    (b"<?xml", 0, "xml"),
+]
+
+_MAX_SCAN = max(off + len(sig) for sig, off, _ in MAGIC_SIGNATURES) + 1
+
+
+def detect_magic(source: str | Path | bytes, *, cap_bytes: int | None = None) -> Result:
+    """Detect using custom magic signatures, falling back to normal detection."""
+    payload = _load_bytes(source, cap_bytes or _MAX_SCAN)
+    for sig, off, engine in MAGIC_SIGNATURES:
+        end = off + len(sig)
+        if len(payload) >= end and payload[off:end] == sig:
+            return get_instance(engine)(payload)
+    # fallback to standard autodetection
+    return detect(payload if isinstance(source, (bytes, bytearray)) else source, cap_bytes=cap_bytes)

--- a/readme.md
+++ b/readme.md
@@ -30,11 +30,13 @@ Probium is a fast, modular content analysis tool that detects and classifies fil
 
 
 ### 1) Import
-from probium import detect, scan_dir
+from probium import detect, detect_magic, scan_dir
 
 ### 2) Peek at one file
 meta = detect("sample.pdf")            # returns a rich Pydantic model
 print("SHA-256 🔮", meta.hash.sha256)  # 🍇 easy attribute access
+
+meta_fast = detect_magic(b"%PDF-1.4\n...")  # use magic-number lookup
 
 ### 3) Fine-tune if you like
 meta = detect(

--- a/tests/test_magic_service.py
+++ b/tests/test_magic_service.py
@@ -1,0 +1,8 @@
+from probium import detect_magic
+from .test_engines import BASE_SAMPLES
+
+
+def test_magic_service_detects_samples():
+    for payload in BASE_SAMPLES.values():
+        res_magic = detect_magic(payload)
+        assert res_magic.candidates


### PR DESCRIPTION
## Summary
- expose `detect_magic` in package API
- implement new `magic_service` using custom signature table
- document fast detection in README
- ensure `detect_magic` returns candidates
- add tests for magic detection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859743a168883319f19ca9f138e1040