### PR TITLE
Implement magic signature detection

### DIFF
--- a/probium/__init__.py
+++ b/probium/__init__.py
@@ -1,6 +1,7 @@
 from importlib.metadata import entry_points, version
 from typing import TYPE_CHECKING
 from .core import detect, scan_dir, list_engines
+from .magic_service import detect_magic
 from .trid_multi import detect_with_trid
 from .exceptions import EngineFailure, FastbackError, UnsupportedType
 from .registry import register
@@ -13,6 +14,7 @@ __all__ = [
     "UnsupportedType",
     "EngineFailure",
     "detect_with_trid",
+    "detect_magic",
 ]
 try:
     from .core import detect_async

--- a/probium/engines/cpp.py
+++ b/probium/engines/cpp.py
@@ -5,15 +5,11 @@ from .base import EngineBase
 from ..registry import register
 import logging
 import mimetypes
-import magic
+from ..libmagic import load_magic
 
 logger = logging.getLogger(__name__)
 
-try:
-    _magic = magic.Magic(mime=True)
-except Exception as exc:  # pragma: no cover - lib setup
-    logger.warning("libmagic unavailable: %s", exc)
-    _magic = None
+_magic = load_magic()
 
 @register
 class CppEngine(EngineBase):

--- a/probium/engines/magiclib.py
+++ b/probium/engines/magiclib.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 import logging
 import mimetypes
-import magic
 from ..models import Candidate, Result
 from .base import EngineBase
 from ..registry import register
+from ..libmagic import load_magic
 
 logger = logging.getLogger(__name__)
 
@@ -17,11 +17,7 @@ class MagicLibEngine(EngineBase):
 
     def __init__(self) -> None:
         super().__init__()
-        try:
-            self._magic = magic.Magic(mime=True)
-        except Exception as exc:  # pragma: no cover - library issues
-            logger.warning("libmagic unavailable: %s", exc)
-            self._magic = None
+        self._magic = load_magic()
 
     def sniff(self, payload: bytes) -> Result:
         if self._magic is None:

--- a/probium/engines/php.py
+++ b/probium/engines/php.py
@@ -5,15 +5,11 @@ from .base import EngineBase
 from ..registry import register
 import logging
 import mimetypes
-import magic
+from ..libmagic import load_magic
 
 logger = logging.getLogger(__name__)
 
-try:
-    _magic = magic.Magic(mime=True)
-except Exception as exc:  # pragma: no cover
-    logger.warning("libmagic unavailable: %s", exc)
-    _magic = None
+_magic = load_magic()
 
 @register
 class PHPEngine(EngineBase):

--- a/probium/engines/powershell.py
+++ b/probium/engines/powershell.py
@@ -5,15 +5,11 @@ from .base import EngineBase
 from ..registry import register
 import logging
 import mimetypes
-import magic
+from ..libmagic import load_magic
 
 logger = logging.getLogger(__name__)
 
-try:
-    _magic = magic.Magic(mime=True)
-except Exception as exc:  # pragma: no cover
-    logger.warning("libmagic unavailable: %s", exc)
-    _magic = None
+_magic = load_magic()
 
 @register
 class PowerShellEngine(EngineBase):

--- a/probium/engines/python.py
+++ b/probium/engines/python.py
@@ -5,15 +5,11 @@ from .base import EngineBase
 from ..registry import register
 import logging
 import mimetypes
-import magic
+from ..libmagic import load_magic
 
 logger = logging.getLogger(__name__)
 
-try:
-    _magic = magic.Magic(mime=True)
-except Exception as exc:  # pragma: no cover - lib setup
-    logger.warning("libmagic unavailable: %s", exc)
-    _magic = None
+_magic = load_magic()
 
 _PY_SHEBANG = b"python"
 

--- a/probium/engines/signature.py
+++ b/probium/engines/signature.py
@@ -5,15 +5,11 @@ from .base import EngineBase
 from ..registry import register
 import logging
 import mimetypes
-import magic
+from ..libmagic import load_magic
 
 logger = logging.getLogger(__name__)
 
-try:
-    _magic = magic.Magic(mime=True)
-except Exception as exc:  # pragma: no cover
-    logger.warning("libmagic unavailable: %s", exc)
-    _magic = None
+_magic = load_magic()
 
 # quick byte signature lookups for common formats
 _SIGNATURES: dict[bytes, tuple[str, str]] = {

--- a/probium/engines/swift.py
+++ b/probium/engines/swift.py
@@ -5,15 +5,11 @@ from .base import EngineBase
 from ..registry import register
 import logging
 import mimetypes
-import magic
+from ..libmagic import load_magic
 
 logger = logging.getLogger(__name__)
 
-try:
-    _magic = magic.Magic(mime=True)
-except Exception as exc:  # pragma: no cover
-    logger.warning("libmagic unavailable: %s", exc)
-    _magic = None
+_magic = load_magic()
 
 @register
 class SwiftEngine(EngineBase):

--- a/probium/engines/toml.py
+++ b/probium/engines/toml.py
@@ -5,15 +5,11 @@ from .base import EngineBase
 from ..registry import register
 import logging
 import mimetypes
-import magic
+from ..libmagic import load_magic
 
 logger = logging.getLogger(__name__)
 
-try:
-    _magic = magic.Magic(mime=True)
-except Exception as exc:  # pragma: no cover
-    logger.warning("libmagic unavailable: %s", exc)
-    _magic = None
+_magic = load_magic()
 
 @register
 class TomlEngine(EngineBase):

--- a/probium/engines/xml.py
+++ b/probium/engines/xml.py
@@ -4,15 +4,11 @@ from .base import EngineBase
 from ..registry import register
 import logging
 import mimetypes
-import magic
+from ..libmagic import load_magic
 
 logger = logging.getLogger(__name__)
 
-try:
-    _magic = magic.Magic(mime=True)
-except Exception as exc:  # pragma: no cover
-    logger.warning("libmagic unavailable: %s", exc)
-    _magic = None
+_magic = load_magic()
 
 @register
 class XMLEngine(EngineBase):

--- a/probium/engines/zig.py
+++ b/probium/engines/zig.py
@@ -5,15 +5,11 @@ from .base import EngineBase
 from ..registry import register
 import logging
 import mimetypes
-import magic
+from ..libmagic import load_magic
 
 logger = logging.getLogger(__name__)
 
-try:
-    _magic = magic.Magic(mime=True)
-except Exception as exc:  # pragma: no cover
-    logger.warning("libmagic unavailable: %s", exc)
-    _magic = None
+_magic = load_magic()
 
 @register
 class ZigEngine(EngineBase):

--- a/probium/libmagic.py
+++ b/probium/libmagic.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def load_magic():
+    """Return a libmagic detector or ``None`` if unavailable."""
+    try:
+        import magic  # type: ignore
+    except Exception as exc:  # pragma: no cover - optional dep missing
+        logger.warning("python-magic not installed: %s", exc)
+        return None
+    try:
+        return magic.Magic(mime=True)
+    except Exception as exc:  # pragma: no cover - runtime failure
+        logger.warning("libmagic unavailable: %s", exc)
+        return None

--- a/probium/magic_service.py
+++ b/probium/magic_service.py
@@ -1,0 +1,47 @@
+"""High performance detection using custom magic numbers."""
+from __future__ import annotations
+from pathlib import Path
+
+from .models import Result
+from .core import detect, _load_bytes
+from .registry import get_instance
+
+# tuples of (signature bytes, offset, engine name)
+MAGIC_SIGNATURES: list[tuple[bytes, int, str]] = [
+    (b"MZ", 0, "exe"),
+    (b"%PDF", 0, "pdf"),
+    (b"\x89PNG\r\n\x1a\n", 0, "png"),
+    (b"GIF87a", 0, "image"),
+    (b"GIF89a", 0, "image"),
+    (b"\xff\xd8\xff", 0, "image"),
+    (b"ftyp", 4, "mp4"),
+    (b"ID3", 0, "mp3"),
+    (b"OggS", 0, "ogg"),
+    (b"fLaC", 0, "flac"),
+    (b"RIFF", 0, "wav"),
+    (b"\x1f\x8b", 0, "gzip"),
+    (b"BZh", 0, "bzip2"),
+    (b"7z\xBC\xAF\x27\x1C", 0, "7z"),
+    (b"\xFD7zXZ\x00", 0, "xz"),
+    (b"Rar!", 0, "rar"),
+    (b"BM", 0, "bmp"),
+    (b"\x00\x00\x01\x00", 0, "ico"),
+    (b"SQLite format 3\x00", 0, "sqlite"),
+    (b"\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1", 0, "legacyoffice"),
+    (b"PK\x03\x04", 0, "zipoffice"),
+    (b"ustar", 257, "tar"),
+    (b"<?xml", 0, "xml"),
+]
+
+_MAX_SCAN = max(off + len(sig) for sig, off, _ in MAGIC_SIGNATURES) + 1
+
+
+def detect_magic(source: str | Path | bytes, *, cap_bytes: int | None = None) -> Result:
+    """Detect using custom magic signatures, falling back to normal detection."""
+    payload = _load_bytes(source, cap_bytes or _MAX_SCAN)
+    for sig, off, engine in MAGIC_SIGNATURES:
+        end = off + len(sig)
+        if len(payload) >= end and payload[off:end] == sig:
+            return get_instance(engine)(payload)
+    # fallback to standard autodetection
+    return detect(payload if isinstance(source, (bytes, bytearray)) else source, cap_bytes=cap_bytes)

--- a/readme.md
+++ b/readme.md
@@ -30,11 +30,13 @@ Probium is a fast, modular content analysis tool that detects and classifies fil
 
 
 ### 1) Import
-from probium import detect, scan_dir
+from probium import detect, detect_magic, scan_dir
 
 ### 2) Peek at one file
 meta = detect("sample.pdf")            # returns a rich Pydantic model
 print("SHA-256 🔮", meta.hash.sha256)  # 🍇 easy attribute access
+
+meta_fast = detect_magic(b"%PDF-1.4\n...")  # use magic-number lookup
 
 ### 3) Fine-tune if you like
 meta = detect(

--- a/tests/test_magic_service.py
+++ b/tests/test_magic_service.py
@@ -1,0 +1,8 @@
+from probium import detect_magic
+from .test_engines import BASE_SAMPLES
+
+
+def test_magic_service_detects_samples():
+    for payload in BASE_SAMPLES.values():
+        res_magic = detect_magic(payload)
+        assert res_magic.candidates


### PR DESCRIPTION
## Summary
- expose `detect_magic` in package API
- implement new `magic_service` using custom signature table
- document fast detection in README
- ensure `detect_magic` returns candidates
- add tests for magic detection
- handle missing python-magic dependency gracefully across engines

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859743a168883319f19ca9f138e1040