### PR TITLE
Improve API docs

### DIFF
--- a/probium/cache.py
+++ b/probium/cache.py
@@ -60,6 +60,8 @@ def _des(raw: str) -> Result:
 
 
 def get(path: Path) -> Optional[Result]:
+    """Return a cached :class:`Result` for ``path`` if present."""
+
     key = str(path.resolve())
 
     # L1: RAM
@@ -87,6 +89,8 @@ def get(path: Path) -> Optional[Result]:
 
 
 def put(path: Path, result: Result) -> None:
+    """Store ``result`` in the on-disk and in-memory caches."""
+
     key = str(path.resolve())
     raw = _ser(result)
     with _mem_lock:

--- a/probium/core.py
+++ b/probium/core.py
@@ -143,11 +143,20 @@ try:
     import anyio as _anyio
 
     async def detect_async(source: Any, **kw) -> Result:
+        """Asynchronously call :func:`detect` in a worker thread.
+
+        Parameters and return value are identical to :func:`detect`. The
+        implementation uses ``anyio.to_thread`` when the optional ``anyio``
+        package is installed.
+        """
+
         return await _anyio.to_thread.run_sync(detect, source, **kw)
 except ImportError:  # pragma: no cover - optional dependency
     import asyncio
 
     async def detect_async(source: Any, **kw) -> Result:
+        """Fallback asyncio-based implementation of :func:`detect_async`."""
+
         return await asyncio.to_thread(detect, source, **kw)
 def scan_dir(
     root: str | Path,

--- a/probium/engines/base.py
+++ b/probium/engines/base.py
@@ -15,6 +15,8 @@ class EngineBase(abc.ABC):
         self._lock = threading.RLock()
 
     def __call__(self, payload: bytes) -> Result:
+        """Run :meth:`sniff` with caching and timing instrumentation."""
+
         t0 = time.perf_counter()
         digest = hashlib.md5(payload).hexdigest()
         with self._lock:
@@ -39,4 +41,7 @@ class EngineBase(abc.ABC):
             self._cache[digest] = res
         return res
     @abc.abstractmethod
-    def sniff(self, payload: bytes) -> Result: ...
+    def sniff(self, payload: bytes) -> Result:
+        """Examine ``payload`` and return a :class:`~probium.models.Result`."""
+
+        ...

--- a/probium/models.py
+++ b/probium/models.py
@@ -3,6 +3,13 @@ from typing import Dict, List, Optional
 from pydantic import BaseModel, Field, ConfigDict
 
 class Candidate(BaseModel):
+    """Single MIME guess with an optional extension and confidence score.
+
+    Example
+    -------
+    ``Candidate(media_type="application/pdf", extension="pdf", confidence=0.92)``
+    """
+
     media_type: str
     extension: Optional[str] = None
     confidence: float = Field(ge=0, le=1)
@@ -22,10 +29,10 @@ class Result(BaseModel):
 
 
 class DetectionResult(BaseModel):
+    """Flattened API payload returned by web/CLI commands."""
+
     file_name: str
     detected_type: str
-
-    
     confidence_score: float = Field(ge=0, le=100)
     detection_method: str
     timestamp: str

--- a/probium/registry.py
+++ b/probium/registry.py
@@ -5,10 +5,18 @@ from .exceptions import UnsupportedType
 
 _engines: dict[str, type] = {}
 _engine_instances: dict[str, "EngineBase"] = {}
+
+
 def register(cls):
+    """Decorator to add an engine class to the global registry."""
+
     _engines[cls.name] = cls
     return cls
+
+
 def get(name: str):
+    """Return the engine class associated with ``name``."""
+
     try:
         return _engines[name]
     except KeyError as exc:

--- a/probium/watch.py
+++ b/probium/watch.py
@@ -66,10 +66,14 @@ class WatchContainer:
         self.observer = Observer()
 
     def start(self) -> None:
+        """Begin monitoring ``root`` for filesystem events."""
+
         self.observer.schedule(self.handler, str(self.root), recursive=self.recursive)
         self.observer.start()
 
     def stop(self) -> None:
+        """Stop the observer and wait for the thread to exit."""
+
         self.observer.stop()
         self.observer.join()
 


### PR DESCRIPTION
## Summary
- document async wrapper
- document watcher start/stop
- add registry docstrings
- document Candidate and DetectionResult models
- document cache helpers
- document EngineBase methods

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cachetools')*

------
https://chatgpt.com/codex/tasks/task_e_685c1d1b959c8331b7a699c2ff2286eb