### PR TITLE
Optimize engine loading

### DIFF
--- a/probium/__init__.py
+++ b/probium/__init__.py
@@ -36,7 +36,6 @@ try:
     __version__ = version("probium")
 except Exception:
     __version__ = "0.0.0-dev"
-from . import engines
 
 for ep in entry_points(group="probium.engines"):
     ep.load()

--- a/probium/core.py
+++ b/probium/core.py
@@ -102,11 +102,14 @@ def detect(
     if engine != "auto":
         return get_instance(engine)(payload)
 
-    engines: Sequence[str] = engine_order or list_engines()
     if only is not None:
-        allowed = set(only)
-        engines = [e for e in engines if e in allowed]
-    elif engine == "auto":
+        if engine_order is not None:
+            allowed = set(only)
+            engines = [e for e in engine_order if e in allowed]
+        else:
+            engines = list(only)
+    else:
+        engines = engine_order or list_engines()
         for sig, off, en in MAGIC_SIGNATURES:
             end = off + len(sig)
             if len(payload) >= end and payload[off:end] == sig:

--- a/probium/engines/__init__.py
+++ b/probium/engines/__init__.py
@@ -1,14 +1,53 @@
-# Register your own engine into 'probium/engines/' and it will auto-register here.
+from __future__ import annotations
+import ast
+import logging
 from importlib import import_module
 from pathlib import Path
-import logging
 
 logger = logging.getLogger(__name__)
 
 _pkg_dir = Path(__file__).resolve().parent
-for _file in _pkg_dir.glob("*.py"):
-    if _file.stem != "__init__":
+_BUILTINS: dict[str, str] = {}
+_scanned = False
+
+
+def _ensure_scanned() -> None:
+    global _scanned
+    if _scanned:
+        return
+    for _file in _pkg_dir.glob("*.py"):
+        if _file.stem == "__init__":
+            continue
         try:
-            import_module(f"{__name__}.{_file.stem}")
+            tree = ast.parse(_file.read_text(encoding="utf-8"))
         except Exception as exc:  # pragma: no cover - best effort logging
-            logger.debug("Engine %s failed to load", _file.stem, exc_info=exc)
+            logger.debug("parse failed for %s", _file, exc_info=exc)
+            continue
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef):
+                for stmt in node.body:
+                    if isinstance(stmt, ast.Assign):
+                        for tgt in stmt.targets:
+                            if isinstance(tgt, ast.Name) and tgt.id == "name":
+                                if isinstance(stmt.value, ast.Constant) and isinstance(stmt.value.value, str):
+                                    _BUILTINS[stmt.value.value] = f"{__name__}.{_file.stem}"
+                                break
+    _scanned = True
+
+
+def load_engine(name: str) -> None:
+    """Import the module providing ``name`` if it exists."""
+    _ensure_scanned()
+    mod = _BUILTINS.get(name)
+    if mod:
+        import_module(mod)
+
+
+def load_all() -> None:
+    """Import all builtin engines."""
+    _ensure_scanned()
+    for name in list(_BUILTINS):
+        load_engine(name)
+
+
+__all__: list[str] = []


### PR DESCRIPTION
## Summary
- lazily scan engine modules
- load only requested engines when `--only` is provided
- avoid importing all engines on package import

## Testing
- `pytest -q` *(fails: sample files missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ead1f9dd48331a098807d05067f04