### PR TITLE
Simplify CLI to use detect

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3,50 +3,47 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from .core import detect, scan_dir
+from .core import detect, detect_file, scan_dir
 from .trid_multi import detect_with_trid
 
-def cmd_one(ns: argparse.Namespace) -> None:
-    """Detect a single file and emit JSON."""
-    if ns.trid:
-        res_map = detect_with_trid(
-            ns.file,
+def cmd_detect(ns: argparse.Namespace) -> None:
+    """Detect a file or scan a directory and emit JSON."""
+    target = ns.path
+    if target.is_dir():
+        results: list[dict] = []
+        for path, res in scan_dir(
+            target,
+            pattern=ns.pattern,
+            workers=ns.workers,
             cap_bytes=None,
             only=ns.only,
             extensions=ns.ext,
-        )
-        out = {k: v.model_dump() for k, v in res_map.items()}
+            ignore=ns.ignore,
+        ):
+            entry = {"path": str(path), **res.model_dump()}
+            if ns.trid:
+                trid_res = detect_file(path, engine="trid", cap_bytes=None)
+                entry["trid"] = trid_res.model_dump()
+            results.append(entry)
+        json.dump(results, sys.stdout, indent=None if ns.raw else 2)
     else:
-        res = detect(
-            ns.file,
-            cap_bytes=None,
-            only=ns.only,
-            extensions=ns.ext,
-        )
-        out = res.model_dump()
-    json.dump(out, sys.stdout, indent=None if ns.raw else 2)
-    sys.stdout.write("\n")
-
-
-def cmd_all(ns: argparse.Namespace) -> None:
-    """Walk a directory, run detection on each file, emit one big JSON list."""
-    results: list[dict] = []
-    for path, res in scan_dir(
-        ns.root,
-        pattern=ns.pattern,
-        workers=ns.workers,
-        cap_bytes=None,
-        only=ns.only,
-        extensions=ns.ext,
-        ignore=ns.ignore,
-    ):
-        entry = {"path": str(path), **res.model_dump()}
         if ns.trid:
-            trid_res = detect(path, engine="trid", cap_bytes=None)
-            entry["trid"] = trid_res.model_dump()
-        results.append(entry)
-
-    json.dump(results, sys.stdout, indent=None if ns.raw else 2)
+            res_map = detect_with_trid(
+                target,
+                cap_bytes=None,
+                only=ns.only,
+                extensions=ns.ext,
+            )
+            out = {k: v.model_dump() for k, v in res_map.items()}
+        else:
+            res = detect(
+                target,
+                cap_bytes=None,
+                only=ns.only,
+                extensions=ns.ext,
+            )
+            out = res.model_dump()
+        json.dump(out, sys.stdout, indent=None if ns.raw else 2)
     sys.stdout.write("\n")
 
 
@@ -54,25 +51,18 @@ def cmd_all(ns: argparse.Namespace) -> None:
 def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(prog="probium", description="Content-type detector")
     sub = p.add_subparsers(dest="cmd", required=True)
-    p_one = sub.add_parser("one", help="Detect a single file")
-    p_one.add_argument("file", type=Path, help="Path to file")
-    _add_common_options(p_one)
-    p_one.set_defaults(func=cmd_one)
-
-
-    # all 
-    p_all = sub.add_parser("all", help="Scan directory recursively")
-    p_all.add_argument("root", type=Path, help="Root folder")
-    p_all.add_argument("--pattern", default="**/*", help="Glob pattern (default **/*)")
-    p_all.add_argument("--workers", type=int, default=8, help="Thread-pool size")
-    p_all.add_argument(
+    p_scan = sub.add_parser("detect", help="Detect a file or directory")
+    p_scan.add_argument("path", type=Path, help="File or directory to process")
+    p_scan.add_argument("--pattern", default="**/*", help="Glob pattern (directories)")
+    p_scan.add_argument("--workers", type=int, default=8, help="Thread-pool size")
+    p_scan.add_argument(
         "--ignore",
         nargs="+",
         metavar="DIR",
         help="Directory names to skip during scan",
     )
-    _add_common_options(p_all)
-    p_all.set_defaults(func=cmd_all)
+    _add_common_options(p_scan)
+    p_scan.set_defaults(func=cmd_detect)
 
 
 

--- a/probium/__init__.py
+++ b/probium/__init__.py
@@ -1,6 +1,6 @@
 from importlib.metadata import entry_points, version
 from typing import TYPE_CHECKING
-from .core import detect, scan_dir, list_engines
+from .core import detect, detect_file, scan_dir, list_engines
 from .magic_service import detect_magic
 from .trid_multi import detect_with_trid
 from .watch import watch
@@ -8,6 +8,7 @@ from .exceptions import EngineFailure, FastbackError, UnsupportedType
 from .registry import register
 __all__ = [
     "detect",
+    "detect_file",
     "scan_dir",
     "list_engines",
     "register",

--- a/probium/cli.py
+++ b/probium/cli.py
@@ -3,52 +3,49 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from .core import detect, scan_dir
+from .core import detect, detect_file, scan_dir
 from .trid_multi import detect_with_trid
 from .watch import watch
 import time
 
-def cmd_one(ns: argparse.Namespace) -> None:
-    """Detect a single file and emit JSON."""
-    if ns.trid:
-        res_map = detect_with_trid(
-            ns.file,
+def cmd_detect(ns: argparse.Namespace) -> None:
+    """Detect a file or scan a directory and emit JSON."""
+    target = ns.path
+    if target.is_dir():
+        results: list[dict] = []
+        for path, res in scan_dir(
+            target,
+            pattern=ns.pattern,
+            workers=ns.workers,
             cap_bytes=ns.capbytes,
             only=ns.only,
             extensions=ns.ext,
-        )
-        out = {k: v.model_dump() for k, v in res_map.items()}
+            ignore=ns.ignore,
+        ):
+            entry = {"path": str(path), **res.model_dump()}
+            if ns.trid:
+                trid_res = detect_file(path, engine="trid", cap_bytes=None)
+                entry["trid"] = trid_res.model_dump()
+            results.append(entry)
+        json.dump(results, sys.stdout, indent=None if ns.raw else 2)
     else:
-        res = detect(
-            ns.file,
-            cap_bytes=ns.capbytes,
-            only=ns.only,
-            extensions=ns.ext,
-        )
-        out = res.model_dump()
-    json.dump(out, sys.stdout, indent=None if ns.raw else 2)
-    sys.stdout.write("\n")
-
-
-def cmd_all(ns: argparse.Namespace) -> None:
-    """Walk a directory, run detection on each file, emit one big JSON list."""
-    results: list[dict] = []
-    for path, res in scan_dir(
-        ns.root,
-        pattern=ns.pattern,
-        workers=ns.workers,
-        cap_bytes=ns.capbytes,
-        only=ns.only,
-        extensions=ns.ext,
-        ignore=ns.ignore,
-    ):
-        entry = {"path": str(path), **res.model_dump()}
         if ns.trid:
-            trid_res = detect(path, engine="trid", cap_bytes=None)
-            entry["trid"] = trid_res.model_dump()
-        results.append(entry)
-
-    json.dump(results, sys.stdout, indent=None if ns.raw else 2)
+            res_map = detect_with_trid(
+                target,
+                cap_bytes=ns.capbytes,
+                only=ns.only,
+                extensions=ns.ext,
+            )
+            out = {k: v.model_dump() for k, v in res_map.items()}
+        else:
+            res = detect(
+                target,
+                cap_bytes=ns.capbytes,
+                only=ns.only,
+                extensions=ns.ext,
+            )
+            out = res.model_dump()
+        json.dump(out, sys.stdout, indent=None if ns.raw else 2)
     sys.stdout.write("\n")
 
 def cmd_watch(ns: argparse.Namespace) -> None:
@@ -78,24 +75,18 @@ def cmd_watch(ns: argparse.Namespace) -> None:
 def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(prog="probium", description="Content-type detector")
     sub = p.add_subparsers(dest="cmd", required=True)
-    p_one = sub.add_parser("one", help="Detect a single file")
-    p_one.add_argument("file", type=Path, help="Path to file")
-    _add_common_options(p_one)
-    p_one.set_defaults(func=cmd_one)
-
-    # all
-    p_all = sub.add_parser("all", help="Scan directory")
-    p_all.add_argument("root", type=Path, help="Root folder")
-    p_all.add_argument("--pattern", default="**/*", help="Glob pattern (default **/*)")
-    p_all.add_argument("--workers", type=int, default=8, help="Thread-pool size")
-    p_all.add_argument(
+    p_scan = sub.add_parser("detect", help="Detect a file or directory")
+    p_scan.add_argument("path", type=Path, help="File or directory to process")
+    p_scan.add_argument("--pattern", default="**/*", help="Glob pattern (directories)")
+    p_scan.add_argument("--workers", type=int, default=8, help="Thread-pool size")
+    p_scan.add_argument(
         "--ignore",
         nargs="+",
         metavar="DIR",
         help="Directory names to skip during scan",
     )
-    _add_common_options(p_all)
-    p_all.set_defaults(func=cmd_all)
+    _add_common_options(p_scan)
+    p_scan.set_defaults(func=cmd_detect)
 
     # watch
     p_watch = sub.add_parser("watch", help="Monitor directory for new files")

--- a/readme.md
+++ b/readme.md
@@ -16,13 +16,8 @@ Probium is a fast, modular content analysis tool that detects and classifies fil
 
 ## ☑️ CLI ☑️
 
-### To scan a single file
-"probium one path/to/file"
-
-
-
-### To recursively scan a folder
-"probium all path/to/folder"
+### To detect a file or folder
+"probium detect path/to/target"
 
 
 ### To monitor a folder for new files
@@ -35,7 +30,7 @@ Probium is a fast, modular content analysis tool that detects and classifies fil
 
 ### 1) Import
 
-from probium import detect, detect_magic, scan_dir
+from probium import detect, detect_magic, detect_file
 
 
 ### 2) Peek at one file
@@ -52,7 +47,7 @@ meta = detect(
 )
 
 ### 4) Stream-scan an entire folder
-for path, m in scan_dir("docs", pattern="**/*.pdf", workers=4):
+for path, m in detect("docs", pattern="**/*.pdf", workers=4):
     print(f"{path} → {m.mimetype} · {m.size:,} bytes 🍇")
 
 ### 5) Monitor a folder for new files


### PR DESCRIPTION
## Summary
- replace previous `scan` command and helper with `detect`
- rename single-file detection function to `detect_file`
- adjust CLI and exports accordingly
- update docs for new command

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862a862484c83319a1c4575d710c550