### PR TITLE
Add unified detect command

### DIFF
--- a/probium/cli.py
+++ b/probium/cli.py
@@ -3,52 +3,49 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from .core import detect, scan_dir
+from .core import detect, _detect_file, scan_dir
 from .trid_multi import detect_with_trid
 from .watch import watch
 import time
 
-def cmd_one(ns: argparse.Namespace) -> None:
-    """Detect a single file and emit JSON."""
-    if ns.trid:
-        res_map = detect_with_trid(
-            ns.file,
+def cmd_detect(ns: argparse.Namespace) -> None:
+    """Detect a file or directory and emit JSON."""
+    target = ns.path
+    if target.is_dir():
+        results: list[dict] = []
+        for path, res in scan_dir(
+            target,
+            pattern=ns.pattern,
+            workers=ns.workers,
             cap_bytes=ns.capbytes,
             only=ns.only,
             extensions=ns.ext,
-        )
-        out = {k: v.model_dump() for k, v in res_map.items()}
+            ignore=ns.ignore,
+        ):
+            entry = {"path": str(path), **res.model_dump()}
+            if ns.trid:
+                trid_res = _detect_file(path, engine="trid", cap_bytes=None)
+                entry["trid"] = trid_res.model_dump()
+            results.append(entry)
+        json.dump(results, sys.stdout, indent=None if ns.raw else 2)
     else:
-        res = detect(
-            ns.file,
-            cap_bytes=ns.capbytes,
-            only=ns.only,
-            extensions=ns.ext,
-        )
-        out = res.model_dump()
-    json.dump(out, sys.stdout, indent=None if ns.raw else 2)
-    sys.stdout.write("\n")
-
-
-def cmd_all(ns: argparse.Namespace) -> None:
-    """Walk a directory, run detection on each file, emit one big JSON list."""
-    results: list[dict] = []
-    for path, res in scan_dir(
-        ns.root,
-        pattern=ns.pattern,
-        workers=ns.workers,
-        cap_bytes=ns.capbytes,
-        only=ns.only,
-        extensions=ns.ext,
-        ignore=ns.ignore,
-    ):
-        entry = {"path": str(path), **res.model_dump()}
         if ns.trid:
-            trid_res = detect(path, engine="trid", cap_bytes=None)
-            entry["trid"] = trid_res.model_dump()
-        results.append(entry)
-
-    json.dump(results, sys.stdout, indent=None if ns.raw else 2)
+            res_map = detect_with_trid(
+                target,
+                cap_bytes=ns.capbytes,
+                only=ns.only,
+                extensions=ns.ext,
+            )
+            out = {k: v.model_dump() for k, v in res_map.items()}
+        else:
+            res = _detect_file(
+                target,
+                cap_bytes=ns.capbytes,
+                only=ns.only,
+                extensions=ns.ext,
+            )
+            out = res.model_dump()
+        json.dump(out, sys.stdout, indent=None if ns.raw else 2)
     sys.stdout.write("\n")
 
 def cmd_watch(ns: argparse.Namespace) -> None:
@@ -78,24 +75,19 @@ def cmd_watch(ns: argparse.Namespace) -> None:
 def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(prog="probium", description="Content-type detector")
     sub = p.add_subparsers(dest="cmd", required=True)
-    p_one = sub.add_parser("one", help="Detect a single file")
-    p_one.add_argument("file", type=Path, help="Path to file")
-    _add_common_options(p_one)
-    p_one.set_defaults(func=cmd_one)
 
-    # all
-    p_all = sub.add_parser("all", help="Scan directory")
-    p_all.add_argument("root", type=Path, help="Root folder")
-    p_all.add_argument("--pattern", default="**/*", help="Glob pattern (default **/*)")
-    p_all.add_argument("--workers", type=int, default=8, help="Thread-pool size")
-    p_all.add_argument(
+    p_det = sub.add_parser("detect", help="Detect a file or directory")
+    p_det.add_argument("path", type=Path, help="File or directory path")
+    p_det.add_argument("--pattern", default="**/*", help="Glob pattern for directories")
+    p_det.add_argument("--workers", type=int, default=8, help="Thread-pool size")
+    p_det.add_argument(
         "--ignore",
         nargs="+",
         metavar="DIR",
         help="Directory names to skip during scan",
     )
-    _add_common_options(p_all)
-    p_all.set_defaults(func=cmd_all)
+    _add_common_options(p_det)
+    p_det.set_defaults(func=cmd_detect)
 
     # watch
     p_watch = sub.add_parser("watch", help="Monitor directory for new files")

--- a/probium/core.py
+++ b/probium/core.py
@@ -35,7 +35,7 @@ def _load_bytes(source: str | Path | bytes, cap: int | None) -> bytes:
             return b""
     return source[:cap] if cap else source
 
-def detect(
+def _detect_file(
     source: str | Path | bytes,
     engine: str = "auto",
     *,
@@ -49,6 +49,9 @@ def detect(
     cache: bool = True,
 ) -> Result:
     """Identify ``source`` using registered engines.
+
+    This low-level helper processes a single file or byte sequence. Use
+    :func:`detect` for auto-detection of paths that may be directories.
 
     Parameters
     ----------
@@ -142,6 +145,27 @@ def detect(
     if cache and isinstance(source, (str, Path)):
         cache_put(Path(source), best)
     return best
+
+
+def detect(
+    source: str | Path | bytes,
+    *,
+    pattern: str = "**/*",
+    workers: int = os.cpu_count() or 4,
+    ignore: Iterable[str] | None = None,
+    **kw,
+) -> Result | Iterable[tuple[Path, Result]]:
+    """Detect a single file or recursively scan a directory.
+
+    If ``source`` is a directory path, this function yields ``(path, Result)``
+    tuples for each entry, delegating to :func:`scan_dir`. Otherwise a single
+    :class:`Result` is returned.
+    """
+
+    if isinstance(source, (str, Path)) and Path(source).is_dir():
+        return scan_dir(source, pattern=pattern, workers=workers, ignore=ignore, **kw)
+
+    return _detect_file(source, **kw)
 try:
     import anyio as _anyio
     from functools import partial
@@ -156,14 +180,14 @@ try:
         ensure ``detect`` receives them.
         """
 
-        return await _anyio.to_thread.run_sync(partial(detect, source, **kw))
+        return await _anyio.to_thread.run_sync(partial(_detect_file, source, **kw))
 except ImportError:  # pragma: no cover - optional dependency
     import asyncio
 
     async def detect_async(source: Any, **kw) -> Result:
         """Fallback asyncio-based implementation of :func:`detect_async`."""
 
-        return await asyncio.to_thread(detect, source, **kw)
+        return await asyncio.to_thread(_detect_file, source, **kw)
 def scan_dir(
     root: str | Path,
     *,
@@ -239,7 +263,7 @@ def scan_dir(
 
     with cf.ThreadPoolExecutor(max_workers=workers) as ex:
         futs = {
-            ex.submit(detect, p, only=only, extensions=extensions, **kw): p
+            ex.submit(_detect_file, p, only=only, extensions=extensions, **kw): p
             for p in paths
         }
 

--- a/probium/magic_service.py
+++ b/probium/magic_service.py
@@ -66,6 +66,6 @@ def detect_magic(source: str | Path | bytes, *, cap_bytes: int | None = None) ->
             return res
     # fallback to standard autodetection
 
-    from .core import detect
+    from .core import _detect_file as detect
 
     return detect(payload if isinstance(source, (bytes, bytearray)) else source, cap_bytes=cap_bytes)

--- a/probium/trid_multi.py
+++ b/probium/trid_multi.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any, Iterable
-from .core import detect
+from .core import _detect_file as detect
 from .models import Result
 
 

--- a/probium/watch.py
+++ b/probium/watch.py
@@ -8,7 +8,7 @@ import logging
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler, FileSystemEvent
 
-from .core import detect
+from .core import _detect_file as detect
 from .models import Result
 
 logger = logging.getLogger(__name__)

--- a/readme.md
+++ b/readme.md
@@ -16,13 +16,8 @@ Probium is a fast, modular content analysis tool that detects and classifies fil
 
 ## ☑️ CLI ☑️
 
-### To scan a single file
-"probium one path/to/file"
-
-
-
-### To recursively scan a folder
-"probium all path/to/folder"
+### To scan a file or folder
+"probium detect path/to/file_or_folder"
 
 
 ### To monitor a folder for new files


### PR DESCRIPTION
## Summary
- add `_detect_file` internal helper
- implement `detect` that handles files and directories
- simplify CLI to one `detect` command
- update watchers and helpers to use `_detect_file`
- document new CLI usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862afb520d083318161745a00859a12