### PR TITLE
Add local API routes

### DIFF
--- a/app/api/v1/engines/route.ts
+++ b/app/api/v1/engines/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server'
+import { spawn } from 'child_process'
+
+async function getEngines(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const code = "import json, probium.registry as r; print(json.dumps({'engines': r.list_engines(), 'total': len(r.list_engines())}))"
+    const proc = spawn('python3', ['-c', code])
+    let out = ''
+    proc.stdout.on('data', (d) => { out += d })
+    proc.stderr.on('data', (d) => { out += d })
+    proc.on('close', (c) => {
+      if (c === 0) resolve(out)
+      else reject(new Error(out))
+    })
+  })
+}
+
+export async function GET() {
+  try {
+    const res = await getEngines()
+    return NextResponse.json(JSON.parse(res))
+  } catch (err: any) {
+    return NextResponse.json({ error: String(err) }, { status: 500 })
+  }
+}

--- a/app/api/v1/scan/file/route.ts
+++ b/app/api/v1/scan/file/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { spawn } from 'child_process'
+import { promises as fs } from 'fs'
+import os from 'os'
+import path from 'path'
+
+async function runPythonDetect(filePath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('python3', ['-m', 'probium.cli', 'detect', filePath, '--raw'])
+    let out = ''
+    proc.stdout.on('data', (d) => { out += d })
+    proc.stderr.on('data', (d) => { out += d })
+    proc.on('close', (code) => {
+      if (code === 0) resolve(out)
+      else reject(new Error(out))
+    })
+  })
+}
+
+export async function POST(req: NextRequest) {
+  const data = await req.formData()
+  const file = data.get('file')
+  if (!(file instanceof Blob)) {
+    return NextResponse.json({ error: 'file field missing' }, { status: 400 })
+  }
+  const buf = Buffer.from(await file.arrayBuffer())
+  const temp = path.join(os.tmpdir(), `probium-${Date.now()}`)
+  await fs.writeFile(temp, buf)
+  try {
+    const res = await runPythonDetect(temp)
+    await fs.unlink(temp)
+    return NextResponse.json({ result: JSON.parse(res) })
+  } catch (err: any) {
+    await fs.unlink(temp).catch(() => {})
+    return NextResponse.json({ error: String(err) }, { status: 500 })
+  }
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,4 +1,5 @@
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000"
+// Default to same-origin when no API URL is provided.
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || ""
 
 export interface ScanResult {
   id: string

--- a/probium/launcher.py
+++ b/probium/launcher.py
@@ -1,0 +1,51 @@
+"""Launch the Next.js UI for Probium."""
+from __future__ import annotations
+
+import subprocess
+import webbrowser
+from pathlib import Path
+
+
+def _start_frontend() -> subprocess.Popen[bytes]:
+    """Start the Next.js development server.
+
+    We prefer ``pnpm`` but fall back to ``npm`` if ``pnpm`` isn't installed.
+    ``FileNotFoundError`` is raised when neither tool exists.
+    """
+    root = Path(__file__).resolve().parents[1]
+
+    commands = [["pnpm", "dev"], ["npm", "run", "dev"]]
+    last_err: Exception | None = None
+    for cmd in commands:
+        try:
+            return subprocess.Popen(
+                cmd,
+                cwd=str(root),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
+        except FileNotFoundError as exc:  # command not found
+            last_err = exc
+
+    assert last_err is not None
+    raise FileNotFoundError(
+        "Neither 'pnpm' nor 'npm' was found. Please install Node.js and pnpm "
+        "(https://pnpm.io) before running the UI"
+    ) from last_err
+
+
+def main() -> None:
+    frontend_proc = _start_frontend()
+    webbrowser.open("http://127.0.0.1:3000")
+
+    try:
+        frontend_proc.wait()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        frontend_proc.terminate()
+        frontend_proc.wait()
+
+
+if __name__ == "__main__":
+    main()

--- a/probium/ui/index.html
+++ b/probium/ui/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Probium UI</title>
+</head>
+<body>
+    <h1>Probium UI placeholder</h1>
+    <p>If you see this page, the React frontend has not been built.</p>
+    <p>Run <code>pnpm install && pnpm build</code> to build the UI, then launch it with <code>probium-ui</code>.</p>
+</body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
 [project.scripts]
 probium = "probium.cli:main"
+probium-ui = "probium.launcher:main"
 
 [tool.setuptools]
 package-dir = {"" = "."}

--- a/readme.md
+++ b/readme.md
@@ -57,3 +57,24 @@ def handle(path, result):
 wc = watch("incoming", handle, extensions=["pdf", "docx"])
 
 wc.stop()
+
+## 🖥️ UI Launcher 🖥️
+
+Install Node.js (version 18 or newer) and the ``pnpm`` package manager. If
+``pnpm`` isn't available, install it with ``npm install -g pnpm``. Then install
+the UI dependencies once:
+
+```
+pnpm install
+```
+
+Then start the UI with:
+
+```
+probium-ui
+```
+
+This command launches the Next.js interface which internally calls the
+``probium`` library via built‑in API routes. ``probium-ui`` tries to run ``pnpm
+dev`` and falls back to ``npm run dev`` if ``pnpm`` is missing. Your browser will
+open at `http://localhost:3000`.


### PR DESCRIPTION
## Summary
- add Next.js API routes calling into Python CLI
- adjust launcher to only run the Next.js UI
- default API calls to same origin
- document new UI workflow and update placeholder
- implement fallback to npm when pnpm is missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862e3d2a61c8331bb397b87784fffbf