### PR TITLE
Proxy Next.js API to backend

### DIFF
--- a/app/api/v1/engines/route.ts
+++ b/app/api/v1/engines/route.ts
@@ -1,24 +1,15 @@
 import { NextResponse } from 'next/server'
-import { spawn } from 'child_process'
 
-async function getEngines(): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const code = "import json, probium.registry as r; print(json.dumps({'engines': r.list_engines(), 'total': len(r.list_engines())}))"
-    const proc = spawn('python3', ['-c', code])
-    let out = ''
-    proc.stdout.on('data', (d) => { out += d })
-    proc.stderr.on('data', (d) => { out += d })
-    proc.on('close', (c) => {
-      if (c === 0) resolve(out)
-      else reject(new Error(out))
-    })
-  })
-}
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000'
 
 export async function GET() {
   try {
-    const res = await getEngines()
-    return NextResponse.json(JSON.parse(res))
+    const res = await fetch(`${BACKEND_URL}/api/v1/engines`)
+    const text = await res.text()
+    return new NextResponse(text, {
+      status: res.status,
+      headers: { 'Content-Type': res.headers.get('content-type') || 'application/json' },
+    })
   } catch (err: any) {
     return NextResponse.json({ error: String(err) }, { status: 500 })
   }

--- a/app/api/v1/engines/status/route.ts
+++ b/app/api/v1/engines/status/route.ts
@@ -1,14 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextResponse } from 'next/server'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000'
 
-export async function POST(req: NextRequest) {
+export async function GET() {
   try {
-    const data = await req.formData()
-    const res = await fetch(`${BACKEND_URL}/api/v1/scan/file`, {
-      method: 'POST',
-      body: data,
-    })
+    const res = await fetch(`${BACKEND_URL}/api/v1/engines/status`)
     const text = await res.text()
     return new NextResponse(text, {
       status: res.status,

--- a/app/api/v1/scan/[scan_id]/status/route.ts
+++ b/app/api/v1/scan/[scan_id]/status/route.ts
@@ -1,14 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextResponse } from 'next/server'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000'
 
-export async function POST(req: NextRequest) {
+export async function GET(request: Request, { params }: { params: { scan_id: string } }) {
   try {
-    const data = await req.formData()
-    const res = await fetch(`${BACKEND_URL}/api/v1/scan/file`, {
-      method: 'POST',
-      body: data,
-    })
+    const res = await fetch(`${BACKEND_URL}/api/v1/scan/${params.scan_id}/status`)
     const text = await res.text()
     return new NextResponse(text, {
       status: res.status,

--- a/app/api/v1/scan/batch/route.ts
+++ b/app/api/v1/scan/batch/route.ts
@@ -5,7 +5,7 @@ const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000'
 export async function POST(req: NextRequest) {
   try {
     const data = await req.formData()
-    const res = await fetch(`${BACKEND_URL}/api/v1/scan/file`, {
+    const res = await fetch(`${BACKEND_URL}/api/v1/scan/batch`, {
       method: 'POST',
       body: data,
     })

--- a/app/api/v1/scan/history/route.ts
+++ b/app/api/v1/scan/history/route.ts
@@ -2,13 +2,10 @@ import { NextRequest, NextResponse } from 'next/server'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000'
 
-export async function POST(req: NextRequest) {
+export async function GET(req: NextRequest) {
   try {
-    const data = await req.formData()
-    const res = await fetch(`${BACKEND_URL}/api/v1/scan/file`, {
-      method: 'POST',
-      body: data,
-    })
+    const url = new URL(req.url)
+    const res = await fetch(`${BACKEND_URL}/api/v1/scan/history${url.search}`)
     const text = await res.text()
     return new NextResponse(text, {
       status: res.status,

--- a/app/api/v1/system/metrics/route.ts
+++ b/app/api/v1/system/metrics/route.ts
@@ -1,14 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextResponse } from 'next/server'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000'
 
-export async function POST(req: NextRequest) {
+export async function GET() {
   try {
-    const data = await req.formData()
-    const res = await fetch(`${BACKEND_URL}/api/v1/scan/file`, {
-      method: 'POST',
-      body: data,
-    })
+    const res = await fetch(`${BACKEND_URL}/api/v1/system/metrics`)
     const text = await res.text()
     return new NextResponse(text, {
       status: res.status,

--- a/readme.md
+++ b/readme.md
@@ -81,3 +81,17 @@ This command launches the Next.js interface which internally calls the
 dev`` and falls back to ``npm run dev`` if ``pnpm`` is missing. Your browser will
 open at `http://localhost:3000`.
 
+### Backend API
+
+The frontend communicates with a FastAPI backend that exposes Probium's
+functionality. Start the backend with:
+
+```
+cd backend && ./start.sh
+```
+
+By default the UI expects the backend to be reachable at
+`http://localhost:8000`. You can override this by setting the environment
+variable `BACKEND_URL` (used by Next.js API routes) or
+`NEXT_PUBLIC_API_URL` when launching the UI.
+


### PR DESCRIPTION
## Summary
- proxy API routes to the FastAPI backend instead of spawning Python
- expose additional endpoints required by the UI
- document backend start instructions and env vars

## Testing
- `npm run lint` *(fails: next not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863e7556cf8833187f071037ca9f94b