### PR TITLE
Proxy Next.js API to backend

### DIFF
--- a/app/api/v1/engines/route.ts
+++ b/app/api/v1/engines/route.ts
@@ -1,24 +1,15 @@
 import { NextResponse } from 'next/server'
-import { spawn } from 'child_process'
 
-async function getEngines(): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const code = "import json, probium.registry as r; print(json.dumps({'engines': r.list_engines(), 'total': len(r.list_engines())}))"
-    const proc = spawn('python3', ['-c', code])
-    let out = ''
-    proc.stdout.on('data', (d) => { out += d })
-    proc.stderr.on('data', (d) => { out += d })
-    proc.on('close', (c) => {
-      if (c === 0) resolve(out)
-      else reject(new Error(out))
-    })
-  })
-}
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000'
 
 export async function GET() {
   try {
-    const res = await getEngines()
-    return NextResponse.json(JSON.parse(res))
+    const res = await fetch(`${BACKEND_URL}/api/v1/engines`)
+    const text = await res.text()
+    return new NextResponse(text, {
+      status: res.status,
+      headers: { 'Content-Type': res.headers.get('content-type') || 'application/json' },
+    })
   } catch (err: any) {
     return NextResponse.json({ error: String(err) }, { status: 500 })
   }

--- a/app/api/v1/engines/status/route.ts
+++ b/app/api/v1/engines/status/route.ts
@@ -1,14 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextResponse } from 'next/server'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000'
 
-export async function POST(req: NextRequest) {
+export async function GET() {
   try {
-    const data = await req.formData()
-    const res = await fetch(`${BACKEND_URL}/api/v1/scan/file`, {
-      method: 'POST',
-      body: data,
-    })
+    const res = await fetch(`${BACKEND_URL}/api/v1/engines/status`)
     const text = await res.text()
     return new NextResponse(text, {
       status: res.status,

--- a/app/api/v1/scan/[scan_id]/status/route.ts
+++ b/app/api/v1/scan/[scan_id]/status/route.ts
@@ -1,14 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextResponse } from 'next/server'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000'
 
-export async function POST(req: NextRequest) {
+export async function GET(request: Request, { params }: { params: { scan_id: string } }) {
   try {
-    const data = await req.formData()
-    const res = await fetch(`${BACKEND_URL}/api/v1/scan/file`, {
-      method: 'POST',
-      body: data,
-    })
+    const res = await fetch(`${BACKEND_URL}/api/v1/scan/${params.scan_id}/status`)
     const text = await res.text()
     return new NextResponse(text, {
       status: res.status,

--- a/app/api/v1/scan/batch/route.ts
+++ b/app/api/v1/scan/batch/route.ts
@@ -5,7 +5,7 @@ const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000'
 export async function POST(req: NextRequest) {
   try {
     const data = await req.formData()
-    const res = await fetch(`${BACKEND_URL}/api/v1/scan/file`, {
+    const res = await fetch(`${BACKEND_URL}/api/v1/scan/batch`, {
       method: 'POST',
       body: data,
     })

--- a/app/api/v1/scan/history/route.ts
+++ b/app/api/v1/scan/history/route.ts
@@ -2,13 +2,10 @@ import { NextRequest, NextResponse } from 'next/server'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000'
 
-export async function POST(req: NextRequest) {
+export async function GET(req: NextRequest) {
   try {
-    const data = await req.formData()
-    const res = await fetch(`${BACKEND_URL}/api/v1/scan/file`, {
-      method: 'POST',
-      body: data,
-    })
+    const url = new URL(req.url)
+    const res = await fetch(`${BACKEND_URL}/api/v1/scan/history${url.search}`)
     const text = await res.text()
     return new NextResponse(text, {
       status: res.status,

--- a/app/api/v1/system/metrics/route.ts
+++ b/app/api/v1/system/metrics/route.ts
@@ -1,14 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextResponse } from 'next/server'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000'
 
-export async function POST(req: NextRequest) {
+export async function GET() {
   try {
-    const data = await req.formData()
-    const res = await fetch(`${BACKEND_URL}/api/v1/scan/file`, {
-      method: 'POST',
-      body: data,
-    })
+    const res = await fetch(`${BACKEND_URL}/api/v1/system/metrics`)
     const text = await res.text()
     return new NextResponse(text, {
       status: res.status,

--- a/probium/engines/csv.py
+++ b/probium/engines/csv.py
@@ -1,66 +1,129 @@
 from __future__ import annotations
 
+import csv
+import io
+import logging
+import mimetypes
+import re
+
 from ..scoring import score_magic, score_tokens
 from ..models import Candidate, Result
 from .base import EngineBase
 from ..registry import register
-import csv, io
+from ..libmagic import load_magic
+
+logger = logging.getLogger(__name__)
+
+_magic = load_magic()
+
 
 @register
 class CSVEngine(EngineBase):
     name = "csv"
     cost = 0.05
 
-    #Possible delimiters to check for in CSV files
+    # Possible delimiters to check for in CSV files
     DELIMS = ",;\t|"
 
     MIN_ROWS = 3
+    MIN_COLS = 2
+    SAMPLE_LINES = 20
+
+    _TOKEN_RE = re.compile(r"[,\t;|]")
+    _MAGIC = [b"\xEF\xBB\xBF", b"sep="]
+
+    def _make_result(
+        self,
+        conf: float,
+        token_ratio: float,
+        *,
+        partial: bool = False,
+        magic_len: int | None = None,
+    ) -> Result:
+        """Build a :class:`Result` with common metadata."""
+
+        breakdown = {"token_ratio": round(token_ratio, 3), "partial": partial}
+        if magic_len is not None:
+            breakdown["magic_len"] = float(magic_len)
+
+        cand = Candidate(
+            media_type="text/csv",
+            extension="csv",
+            confidence=conf,
+            breakdown=breakdown,
+        )
+        return Result(candidates=[cand])
 
     def sniff(self, payload: bytes) -> Result:
+        if _magic is not None:
+            try:
+                mime = _magic.from_buffer(payload)
+            except Exception as exc:  # pragma: no cover - rare
+                logger.warning("libmagic failed: %s", exc)
+            else:
+                if mime and "csv" in mime:
+                    ext = (mimetypes.guess_extension(mime) or "").lstrip(".") or "csv"
+                    cand = Candidate(
+                        media_type=mime,
+                        extension=ext,
+                        confidence=score_tokens(1.0),
+                        breakdown={"token_ratio": 1.0, "libmagic": True},
+                    )
+                    return Result(candidates=[cand])
+
         try:
-            #Decode payload as UTF-8, replacing invalid characters
-            text = payload.decode("utf-8", errors="replace")
-
-            if "�" in text or any(ord(c) < 32 and c not in "\n\r\t" for c in text):
-                return Result(candidates=[])
-            lines = text.splitlines()
-            if len(lines) < self.MIN_ROWS:
-                return Result(candidates=[])
-
-            #Use only the first 10 lines as a sample
-            sample_text = "\n".join(lines[:10])
-
-            #Attempt to detect the delimiter
-            dialect = csv.Sniffer().sniff(sample_text, self.DELIMS)
-
-            #Check that the detected delimiter is used enough times
-            delim_count = sum(dialect.delimiter in ln for ln in lines[:10])
-            if delim_count < self.MIN_ROWS:
-                return Result(candidates=[])
-
-            #Parse rows using the detected dialect
-            reader = csv.reader(io.StringIO(sample_text), dialect)
-            rows = [row for row in reader if row]
-            if len(rows) < self.MIN_ROWS:
-                return Result(candidates=[])
-
-            #Check if all rows have the same number of columns
-            row_lengths = {len(r) for r in rows}
-            if len(row_lengths) == 1 and list(row_lengths)[0] > 1:
-                #If it looks like it has a header, raise confidence
-                has_header = csv.Sniffer().has_header(sample_text)
-                ratio = 1.0 if has_header else 0.5
-
-                #Construct a Candidate with calculated confidence
-                #(call score_tokens from core.py)
-                cand = Candidate(
-                    media_type="text/csv",
-                    extension="csv",
-                    confidence=score_tokens(ratio),
-                    breakdown={"token_ratio": ratio},
-                )
-                return Result(candidates=[cand])
+            text = payload.decode("utf-8", errors="ignore")
         except Exception:
-            #On any failure, return no candidates
-            pass
-        return Result(candidates=[])
+            return Result(candidates=[])
+
+        stripped = text.lstrip()
+        magic_hit = None
+        for m in self._MAGIC:
+            if stripped.startswith(m.decode("latin1")):
+                magic_hit = m
+                break
+
+        text = text.strip()
+        if not text:
+            return Result(candidates=[])
+
+        lines = text.splitlines()
+        sample = "\n".join(lines[: self.SAMPLE_LINES])
+
+        try:
+            dialect = csv.Sniffer().sniff(sample, self.DELIMS)
+        except Exception:
+            return Result(candidates=[])
+
+        delim = dialect.delimiter
+        token_count = len(self._TOKEN_RE.findall(sample))
+        token_ratio = token_count / max(len(sample), 1)
+
+        delim_hits = sum(delim in ln for ln in lines[: self.SAMPLE_LINES])
+        if delim_hits < self.MIN_ROWS:
+            return Result(candidates=[])
+
+        try:
+            reader = csv.reader(io.StringIO(sample), dialect)
+            rows = [row for row in reader if row]
+        except Exception:
+            return Result(candidates=[])
+
+        if len(rows) < self.MIN_ROWS:
+            return Result(candidates=[])
+
+        column_counts = {len(r) for r in rows}
+        same_len = len(column_counts) == 1 and next(iter(column_counts)) >= self.MIN_COLS
+
+        has_header = csv.Sniffer().has_header(sample)
+
+        if same_len:
+            conf_base = 0.9 if has_header else 0.7
+        else:
+            conf_base = 0.6
+
+        conf = score_tokens(conf_base)
+        if magic_hit:
+            conf = max(conf, score_magic(len(magic_hit)))
+
+        return self._make_result(conf, token_ratio, partial=not same_len, magic_len=len(magic_hit) if magic_hit else None)

--- a/readme.md
+++ b/readme.md
@@ -81,3 +81,17 @@ This command launches the Next.js interface which internally calls the
 dev`` and falls back to ``npm run dev`` if ``pnpm`` is missing. Your browser will
 open at `http://localhost:3000`.
 
+### Backend API
+
+The frontend communicates with a FastAPI backend that exposes Probium's
+functionality. Start the backend with:
+
+```
+cd backend && ./start.sh
+```
+
+By default the UI expects the backend to be reachable at
+`http://localhost:8000`. You can override this by setting the environment
+variable `BACKEND_URL` (used by Next.js API routes) or
+`NEXT_PUBLIC_API_URL` when launching the UI.
+


### PR DESCRIPTION
## Summary
- proxy API routes to the FastAPI backend instead of spawning Python
- expose additional endpoints required by the UI
- document backend start instructions and env vars
- improve robustness of CSV engine using libmagic, delimiter heuristics and token ratios

## Testing
- `npm run lint` *(fails: next not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863e7556cf8833187f071037ca9f94b