### PR TITLE
Add shared proxy helper

### DIFF
--- a/app/api/_proxy.ts
+++ b/app/api/_proxy.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000'
+
+export async function proxy(path: string, init?: RequestInit) {
+  try {
+    const res = await fetch(`${BACKEND_URL}${path}`, init)
+    const text = await res.text()
+    return new NextResponse(text, {
+      status: res.status,
+      headers: { 'Content-Type': res.headers.get('content-type') || 'application/json' },
+    })
+  } catch (err: any) {
+    return NextResponse.json({ error: String(err) }, { status: 500 })
+  }
+}

--- a/app/api/v1/engines/route.ts
+++ b/app/api/v1/engines/route.ts
@@ -1,16 +1,5 @@
-import { NextResponse } from 'next/server'
-
-const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000'
+import { proxy } from '@/app/api/_proxy'
 
 export async function GET() {
-  try {
-    const res = await fetch(`${BACKEND_URL}/api/v1/engines`)
-    const text = await res.text()
-    return new NextResponse(text, {
-      status: res.status,
-      headers: { 'Content-Type': res.headers.get('content-type') || 'application/json' },
-    })
-  } catch (err: any) {
-    return NextResponse.json({ error: String(err) }, { status: 500 })
-  }
+  return proxy('/api/v1/engines')
 }

--- a/app/api/v1/engines/status/route.ts
+++ b/app/api/v1/engines/status/route.ts
@@ -1,16 +1,5 @@
-import { NextResponse } from 'next/server'
-
-const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000'
+import { proxy } from '@/app/api/_proxy'
 
 export async function GET() {
-  try {
-    const res = await fetch(`${BACKEND_URL}/api/v1/engines/status`)
-    const text = await res.text()
-    return new NextResponse(text, {
-      status: res.status,
-      headers: { 'Content-Type': res.headers.get('content-type') || 'application/json' },
-    })
-  } catch (err: any) {
-    return NextResponse.json({ error: String(err) }, { status: 500 })
-  }
+  return proxy('/api/v1/engines/status')
 }

--- a/app/api/v1/scan/[scan_id]/status/route.ts
+++ b/app/api/v1/scan/[scan_id]/status/route.ts
@@ -1,16 +1,5 @@
-import { NextResponse } from 'next/server'
-
-const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000'
+import { proxy } from '@/app/api/_proxy'
 
 export async function GET(request: Request, { params }: { params: { scan_id: string } }) {
-  try {
-    const res = await fetch(`${BACKEND_URL}/api/v1/scan/${params.scan_id}/status`)
-    const text = await res.text()
-    return new NextResponse(text, {
-      status: res.status,
-      headers: { 'Content-Type': res.headers.get('content-type') || 'application/json' },
-    })
-  } catch (err: any) {
-    return NextResponse.json({ error: String(err) }, { status: 500 })
-  }
+  return proxy(`/api/v1/scan/${params.scan_id}/status`)
 }

--- a/app/api/v1/scan/batch/route.ts
+++ b/app/api/v1/scan/batch/route.ts
@@ -1,20 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
-
-const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000'
+import { NextRequest } from 'next/server'
+import { proxy } from '@/app/api/_proxy'
 
 export async function POST(req: NextRequest) {
-  try {
-    const data = await req.formData()
-    const res = await fetch(`${BACKEND_URL}/api/v1/scan/batch`, {
-      method: 'POST',
-      body: data,
-    })
-    const text = await res.text()
-    return new NextResponse(text, {
-      status: res.status,
-      headers: { 'Content-Type': res.headers.get('content-type') || 'application/json' },
-    })
-  } catch (err: any) {
-    return NextResponse.json({ error: String(err) }, { status: 500 })
-  }
+  const data = await req.formData()
+  return proxy('/api/v1/scan/batch', { method: 'POST', body: data })
 }

--- a/app/api/v1/scan/file/route.ts
+++ b/app/api/v1/scan/file/route.ts
@@ -1,20 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
-
-const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000'
+import { NextRequest } from 'next/server'
+import { proxy } from '@/app/api/_proxy'
 
 export async function POST(req: NextRequest) {
-  try {
-    const data = await req.formData()
-    const res = await fetch(`${BACKEND_URL}/api/v1/scan/file`, {
-      method: 'POST',
-      body: data,
-    })
-    const text = await res.text()
-    return new NextResponse(text, {
-      status: res.status,
-      headers: { 'Content-Type': res.headers.get('content-type') || 'application/json' },
-    })
-  } catch (err: any) {
-    return NextResponse.json({ error: String(err) }, { status: 500 })
-  }
+  const data = await req.formData()
+  return proxy('/api/v1/scan/file', { method: 'POST', body: data })
 }

--- a/app/api/v1/scan/history/route.ts
+++ b/app/api/v1/scan/history/route.ts
@@ -1,17 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
-
-const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000'
+import { NextRequest } from 'next/server'
+import { proxy } from '@/app/api/_proxy'
 
 export async function GET(req: NextRequest) {
-  try {
-    const url = new URL(req.url)
-    const res = await fetch(`${BACKEND_URL}/api/v1/scan/history${url.search}`)
-    const text = await res.text()
-    return new NextResponse(text, {
-      status: res.status,
-      headers: { 'Content-Type': res.headers.get('content-type') || 'application/json' },
-    })
-  } catch (err: any) {
-    return NextResponse.json({ error: String(err) }, { status: 500 })
-  }
+  const url = new URL(req.url)
+  return proxy(`/api/v1/scan/history${url.search}`)
 }

--- a/app/api/v1/system/metrics/route.ts
+++ b/app/api/v1/system/metrics/route.ts
@@ -1,16 +1,5 @@
-import { NextResponse } from 'next/server'
-
-const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000'
+import { proxy } from '@/app/api/_proxy'
 
 export async function GET() {
-  try {
-    const res = await fetch(`${BACKEND_URL}/api/v1/system/metrics`)
-    const text = await res.text()
-    return new NextResponse(text, {
-      status: res.status,
-      headers: { 'Content-Type': res.headers.get('content-type') || 'application/json' },
-    })
-  } catch (err: any) {
-    return NextResponse.json({ error: String(err) }, { status: 500 })
-  }
+  return proxy('/api/v1/system/metrics')
 }


### PR DESCRIPTION
## Summary
- add helper `app/api/_proxy.ts` to forward requests to `BACKEND_URL`
- reuse helper across all API route handlers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863f6f091b08331a79788a1c71ca3b1