### PR TITLE
Fix watch scanning and CSV errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ dependencies = [
   "platformdirs>=4.2",
   "olefile>=0.46",
   "python-magic>=0.4.27",
-  "watchdog>=3.0"
+  "watchdog>=3.0",
+  "chardet>=5.2"
 ]
 authors = [{ name = "probityfilterteam"}]
 [build-system]


### PR DESCRIPTION
## Summary
- handle missing chardet dependency gracefully
- recursively scan moved/created directories when watching

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686406d606288331b492b16633f753b1