### PR TITLE
Improve watch dependency error handling

### DIFF
--- a/probium/cli.py
+++ b/probium/cli.py
@@ -60,13 +60,17 @@ def cmd_watch(ns: argparse.Namespace) -> None:
 
     print(f"Watching {ns.root}... Press Ctrl+C to stop", file=sys.stderr)
     from .watch import watch
-    wc = watch(
-        ns.root,
-        _handle,
-        recursive=ns.recursive,
-        only=ns.only,
-        extensions=ns.ext,
-    )
+    try:
+        wc = watch(
+            ns.root,
+            _handle,
+            recursive=ns.recursive,
+            only=ns.only,
+            extensions=ns.ext,
+        )
+    except RuntimeError as exc:
+        print(exc, file=sys.stderr)
+        return
     try:
         while True:
             time.sleep(0.5)

--- a/probium/watch.py
+++ b/probium/watch.py
@@ -121,9 +121,15 @@ def watch(
 ) -> WatchContainer:
     """Start watching ``root`` and invoke ``callback`` for new files.
 
-    If :mod:`watchdog` is not installed, a stub implementation is used that
-    does not generate events. Install ``watchdog`` to enable real monitoring.
+    If :mod:`watchdog` is not installed, a :class:`RuntimeError` is raised
+    with instructions to install it. Without ``watchdog`` no file events can be
+    generated.
     """
+    if USING_STUB:
+        raise RuntimeError(
+            "watchdog package is required for directory monitoring. "
+            "Install it with 'pip install watchdog'."
+        )
     container = WatchContainer(
         root, callback, recursive=recursive, only=only, extensions=extensions
     )

--- a/readme.md
+++ b/readme.md
@@ -11,8 +11,27 @@ Probium is a fast, modular content analysis tool that detects and classifies fil
 - Parallel scanning with thread pools ✔
 - JSON output for easy integration ✔
 
+
+## Installation
+
+Install Probium and its Python dependencies with ``pip``:
+
+```bash
+pip install probium
+```
+
+If you are working from a source checkout run ``pip install -e .`` instead.
+This includes the ``watchdog`` package so ``probium watch`` can report file
+system events.
+
+If the watch command warns that ``watchdog`` is missing, install it manually:
+
+```bash
+pip install watchdog
+```
+
 ### Usage:
-"*pip install probium*"
+
 
 
 ## ☑️ CLI ☑️

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -116,3 +116,12 @@ def test_detect_async(file_name: str, expect: dict, results_log: list):
     assert cand is not None, "No candidate returned (async)"
     assert cand.media_type == expect["media_type"]
     assert cand.extension == expect["extension"]
+
+
+def test_watch_requires_watchdog(monkeypatch, tmp_path):
+    """watch() should fail when watchdog is unavailable."""
+    import probium.watch as w
+
+    monkeypatch.setattr(w, "USING_STUB", True)
+    with pytest.raises(RuntimeError):
+        w.watch(tmp_path, lambda p, r: None)


### PR DESCRIPTION
## Summary
- raise a runtime error when watchdog isn't installed
- handle that error in the CLI
- clarify README with manual watchdog install instructions
- test watch() fails without watchdog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68654b2f8724833186ecd9dcc12b5cec