### PR TITLE
Update UI color scheme to light theme

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -113,25 +113,25 @@ export default function ProbiumComprehensiveDashboard() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-purple-950 via-purple-900 to-indigo-950">
+    <div className="min-h-screen bg-gradient-to-br from-white via-purple-50 to-white">
       <div className="container mx-auto p-6">
         {/* Header */}
         <div className="mb-8">
           <div className="flex items-center justify-between mb-6">
             <div className="flex items-center gap-4">
-              <div className="w-16 h-16 bg-gradient-to-br from-purple-600 to-purple-800 rounded-xl flex items-center justify-center shadow-lg">
+              <div className="w-16 h-16 bg-gradient-to-br from-purple-400 to-purple-600 rounded-xl flex items-center justify-center shadow-lg">
                 <Shield className="w-8 h-8 text-white" />
               </div>
               <div>
                 <h1 className="text-4xl font-bold text-white mb-2">Probium Advanced Scanner</h1>
-                <p className="text-purple-200">
+                <p className="text-purple-600">
                   Comprehensive file analysis with {availableEngines.length} detection engines
                 </p>
               </div>
             </div>
             <div className="flex items-center gap-4">
               <div className="text-right">
-                <p className="text-sm text-purple-300">System Status</p>
+                <p className="text-sm text-purple-700">System Status</p>
                 <div className="flex items-center gap-2">
                   <div className="w-2 h-2 bg-green-400 rounded-full animate-pulse"></div>
                   <span className="text-green-400 font-medium">Online</span>
@@ -142,56 +142,56 @@ export default function ProbiumComprehensiveDashboard() {
 
           {/* Quick Stats */}
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-4 mb-6">
-            <Card className="bg-purple-900/50 border-purple-700">
+            <Card className="bg-purple-50 border-purple-300">
               <CardContent className="p-4">
                 <div className="flex items-center gap-3">
-                  <Database className="w-8 h-8 text-purple-400" />
+                  <Database className="w-8 h-8 text-purple-600" />
                   <div>
-                    <p className="text-sm text-purple-300">Total Scans</p>
+                    <p className="text-sm text-purple-700">Total Scans</p>
                     <p className="text-xl font-bold text-white">{systemStats.total_scans}</p>
                   </div>
                 </div>
               </CardContent>
             </Card>
-            <Card className="bg-purple-900/50 border-purple-700">
+            <Card className="bg-purple-50 border-purple-300">
               <CardContent className="p-4">
                 <div className="flex items-center gap-3">
                   <Cpu className="w-8 h-8 text-blue-400" />
                   <div>
-                    <p className="text-sm text-purple-300">Active Threads</p>
+                    <p className="text-sm text-purple-700">Active Threads</p>
                     <p className="text-xl font-bold text-white">{systemStats.active_threads}</p>
                   </div>
                 </div>
               </CardContent>
             </Card>
-            <Card className="bg-purple-900/50 border-purple-700">
+            <Card className="bg-purple-50 border-purple-300">
               <CardContent className="p-4">
                 <div className="flex items-center gap-3">
                   <Activity className="w-8 h-8 text-green-400" />
                   <div>
-                    <p className="text-sm text-purple-300">CPU Usage</p>
+                    <p className="text-sm text-purple-700">CPU Usage</p>
                     <p className="text-xl font-bold text-white">{systemStats.cpu_usage.toFixed(1)}%</p>
                   </div>
                 </div>
               </CardContent>
             </Card>
-            <Card className="bg-purple-900/50 border-purple-700">
+            <Card className="bg-purple-50 border-purple-300">
               <CardContent className="p-4">
                 <div className="flex items-center gap-3">
                   <Gauge className="w-8 h-8 text-yellow-400" />
                   <div>
-                    <p className="text-sm text-purple-300">Memory</p>
+                    <p className="text-sm text-purple-700">Memory</p>
                     <p className="text-xl font-bold text-white">{systemStats.memory_usage.toFixed(1)}%</p>
                   </div>
                 </div>
               </CardContent>
             </Card>
-            <Card className="bg-purple-900/50 border-purple-700">
+            <Card className="bg-purple-50 border-purple-300">
               <CardContent className="p-4">
                 <div className="flex items-center gap-3">
                   <Shield className="w-8 h-8 text-red-400" />
                   <div>
-                    <p className="text-sm text-purple-300">Threats</p>
+                    <p className="text-sm text-purple-700">Threats</p>
                     <p className="text-xl font-bold text-white">
                       {scanResults.filter((r) => r.security?.threat_level !== "low").length}
                     </p>
@@ -199,12 +199,12 @@ export default function ProbiumComprehensiveDashboard() {
                 </div>
               </CardContent>
             </Card>
-            <Card className="bg-purple-900/50 border-purple-700">
+            <Card className="bg-purple-50 border-purple-300">
               <CardContent className="p-4">
                 <div className="flex items-center gap-3">
-                  <FileType className="w-8 h-8 text-purple-400" />
+                  <FileType className="w-8 h-8 text-purple-600" />
                   <div>
-                    <p className="text-sm text-purple-300">Engines</p>
+                    <p className="text-sm text-purple-700">Engines</p>
                     <p className="text-xl font-bold text-white">{availableEngines.length}</p>
                   </div>
                 </div>
@@ -215,52 +215,52 @@ export default function ProbiumComprehensiveDashboard() {
 
         {/* Main Interface */}
         <Tabs defaultValue="scanner" className="space-y-6">
-          <TabsList className="grid w-full grid-cols-6 lg:grid-cols-12 bg-purple-900/50 border-purple-700">
-            <TabsTrigger value="scanner" className="data-[state=active]:bg-purple-700">
+          <TabsList className="grid w-full grid-cols-6 lg:grid-cols-12 bg-purple-50 border-purple-300">
+            <TabsTrigger value="scanner" className="data-[state=active]:bg-purple-500">
               <Shield className="w-4 h-4 mr-2" />
               Scanner
             </TabsTrigger>
-            <TabsTrigger value="batch" className="data-[state=active]:bg-purple-700">
+            <TabsTrigger value="batch" className="data-[state=active]:bg-purple-500">
               <Database className="w-4 h-4 mr-2" />
               Batch
             </TabsTrigger>
-            <TabsTrigger value="engines" className="data-[state=active]:bg-purple-700">
+            <TabsTrigger value="engines" className="data-[state=active]:bg-purple-500">
               <Cpu className="w-4 h-4 mr-2" />
               Engines
             </TabsTrigger>
-            <TabsTrigger value="results" className="data-[state=active]:bg-purple-700">
+            <TabsTrigger value="results" className="data-[state=active]:bg-purple-500">
               <BarChart3 className="w-4 h-4 mr-2" />
               Results
             </TabsTrigger>
-            <TabsTrigger value="monitor" className="data-[state=active]:bg-purple-700">
+            <TabsTrigger value="monitor" className="data-[state=active]:bg-purple-500">
               <Activity className="w-4 h-4 mr-2" />
               Monitor
             </TabsTrigger>
-            <TabsTrigger value="analytics" className="data-[state=active]:bg-purple-700">
+            <TabsTrigger value="analytics" className="data-[state=active]:bg-purple-500">
               <BarChart3 className="w-4 h-4 mr-2" />
               Analytics
             </TabsTrigger>
-            <TabsTrigger value="threats" className="data-[state=active]:bg-purple-700">
+            <TabsTrigger value="threats" className="data-[state=active]:bg-purple-500">
               <AlertTriangle className="w-4 h-4 mr-2" />
               Threats
             </TabsTrigger>
-            <TabsTrigger value="registry" className="data-[state=active]:bg-purple-700">
+            <TabsTrigger value="registry" className="data-[state=active]:bg-purple-500">
               <FileType className="w-4 h-4 mr-2" />
               Registry
             </TabsTrigger>
-            <TabsTrigger value="profiler" className="data-[state=active]:bg-purple-700">
+            <TabsTrigger value="profiler" className="data-[state=active]:bg-purple-500">
               <Gauge className="w-4 h-4 mr-2" />
               Profiler
             </TabsTrigger>
-            <TabsTrigger value="api" className="data-[state=active]:bg-purple-700">
+            <TabsTrigger value="api" className="data-[state=active]:bg-purple-500">
               <Code className="w-4 h-4 mr-2" />
               API
             </TabsTrigger>
-            <TabsTrigger value="realtime" className="data-[state=active]:bg-purple-700">
+            <TabsTrigger value="realtime" className="data-[state=active]:bg-purple-500">
               <Eye className="w-4 h-4 mr-2" />
               Live
             </TabsTrigger>
-            <TabsTrigger value="config" className="data-[state=active]:bg-purple-700">
+            <TabsTrigger value="config" className="data-[state=active]:bg-purple-500">
               <Settings className="w-4 h-4 mr-2" />
               Config
             </TabsTrigger>

--- a/components/analytics-dashboard.tsx
+++ b/components/analytics-dashboard.tsx
@@ -118,12 +118,12 @@ export function AnalyticsDashboard({ results, systemStats }: AnalyticsDashboardP
     <div className="space-y-6">
       {/* Analytics Overview */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardContent className="p-4">
             <div className="flex items-center gap-3">
-              <BarChart3 className="w-8 h-8 text-purple-400" />
+              <BarChart3 className="w-8 h-8 text-purple-600" />
               <div>
-                <p className="text-sm text-purple-300">Total Scans</p>
+                <p className="text-sm text-purple-700">Total Scans</p>
                 <p className="text-2xl font-bold text-white">{analytics.totalScans}</p>
               </div>
             </div>
@@ -134,12 +134,12 @@ export function AnalyticsDashboard({ results, systemStats }: AnalyticsDashboardP
           </CardContent>
         </Card>
 
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardContent className="p-4">
             <div className="flex items-center gap-3">
               <CheckCircle className="w-8 h-8 text-green-400" />
               <div>
-                <p className="text-sm text-purple-300">Avg Confidence</p>
+                <p className="text-sm text-purple-700">Avg Confidence</p>
                 <p className="text-2xl font-bold text-white">{(analytics.avgConfidence * 100).toFixed(1)}%</p>
               </div>
             </div>
@@ -150,12 +150,12 @@ export function AnalyticsDashboard({ results, systemStats }: AnalyticsDashboardP
           </CardContent>
         </Card>
 
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardContent className="p-4">
             <div className="flex items-center gap-3">
               <Clock className="w-8 h-8 text-blue-400" />
               <div>
-                <p className="text-sm text-purple-300">Avg Scan Time</p>
+                <p className="text-sm text-purple-700">Avg Scan Time</p>
                 <p className="text-2xl font-bold text-white">{analytics.avgScanTime.toFixed(2)}s</p>
               </div>
             </div>
@@ -166,36 +166,36 @@ export function AnalyticsDashboard({ results, systemStats }: AnalyticsDashboardP
           </CardContent>
         </Card>
 
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardContent className="p-4">
             <div className="flex items-center gap-3">
               <Shield className="w-8 h-8 text-red-400" />
               <div>
-                <p className="text-sm text-purple-300">Threats Detected</p>
+                <p className="text-sm text-purple-700">Threats Detected</p>
                 <p className="text-2xl font-bold text-white">{getThreatSummary().total}</p>
               </div>
             </div>
             <div className="mt-2 flex items-center gap-1 text-xs">
-              <span className="text-purple-400">{getThreatSummary().percentage.toFixed(1)}% of total scans</span>
+              <span className="text-purple-600">{getThreatSummary().percentage.toFixed(1)}% of total scans</span>
             </div>
           </CardContent>
         </Card>
       </div>
 
       {/* Detailed Analytics */}
-      <Card className="bg-purple-900/30 border-purple-700">
+      <Card className="bg-purple-50 border-purple-300">
         <CardHeader>
           <CardTitle className="text-white flex items-center gap-2">
             <Activity className="w-5 h-5" />
             Detailed Analytics
           </CardTitle>
-          <CardDescription className="text-purple-300">
+          <CardDescription className="text-purple-700">
             Comprehensive analysis of scanning patterns and performance metrics
           </CardDescription>
         </CardHeader>
         <CardContent>
           <Tabs defaultValue="overview" className="space-y-4">
-            <TabsList className="grid w-full grid-cols-5 bg-purple-800/50">
+            <TabsList className="grid w-full grid-cols-5 bg-purple-100">
               <TabsTrigger value="overview">Overview</TabsTrigger>
               <TabsTrigger value="filetypes">File Types</TabsTrigger>
               <TabsTrigger value="performance">Performance</TabsTrigger>
@@ -205,16 +205,16 @@ export function AnalyticsDashboard({ results, systemStats }: AnalyticsDashboardP
 
             <TabsContent value="overview" className="space-y-4">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <Card className="bg-purple-800/30 border-purple-600">
+                <Card className="bg-purple-50 border-purple-300">
                   <CardHeader>
                     <CardTitle className="text-white text-lg">Confidence Distribution</CardTitle>
                   </CardHeader>
                   <CardContent className="space-y-4">
                     <div className="space-y-3">
                       <div className="flex justify-between items-center">
-                        <span className="text-purple-300">High (≥90%)</span>
+                        <span className="text-purple-700">High (≥90%)</span>
                         <div className="flex items-center gap-2">
-                          <div className="w-24 bg-purple-900/50 rounded-full h-2">
+                          <div className="w-24 bg-purple-50 rounded-full h-2">
                             <div
                               className="bg-green-500 h-2 rounded-full"
                               style={{
@@ -226,9 +226,9 @@ export function AnalyticsDashboard({ results, systemStats }: AnalyticsDashboardP
                         </div>
                       </div>
                       <div className="flex justify-between items-center">
-                        <span className="text-purple-300">Medium (70-89%)</span>
+                        <span className="text-purple-700">Medium (70-89%)</span>
                         <div className="flex items-center gap-2">
-                          <div className="w-24 bg-purple-900/50 rounded-full h-2">
+                          <div className="w-24 bg-purple-50 rounded-full h-2">
                             <div
                               className="bg-yellow-500 h-2 rounded-full"
                               style={{
@@ -240,9 +240,9 @@ export function AnalyticsDashboard({ results, systemStats }: AnalyticsDashboardP
                         </div>
                       </div>
                       <div className="flex justify-between items-center">
-                        <span className="text-purple-300">Low (&lt;70%)</span>
+                        <span className="text-purple-700">Low (&lt;70%)</span>
                         <div className="flex items-center gap-2">
-                          <div className="w-24 bg-purple-900/50 rounded-full h-2">
+                          <div className="w-24 bg-purple-50 rounded-full h-2">
                             <div
                               className="bg-red-500 h-2 rounded-full"
                               style={{
@@ -257,16 +257,16 @@ export function AnalyticsDashboard({ results, systemStats }: AnalyticsDashboardP
                   </CardContent>
                 </Card>
 
-                <Card className="bg-purple-800/30 border-purple-600">
+                <Card className="bg-purple-50 border-purple-300">
                   <CardHeader>
                     <CardTitle className="text-white text-lg">File Size Distribution</CardTitle>
                   </CardHeader>
                   <CardContent className="space-y-4">
                     <div className="space-y-3">
                       <div className="flex justify-between items-center">
-                        <span className="text-purple-300">Small (&lt;1MB)</span>
+                        <span className="text-purple-700">Small (&lt;1MB)</span>
                         <div className="flex items-center gap-2">
-                          <div className="w-24 bg-purple-900/50 rounded-full h-2">
+                          <div className="w-24 bg-purple-50 rounded-full h-2">
                             <div
                               className="bg-blue-500 h-2 rounded-full"
                               style={{
@@ -278,9 +278,9 @@ export function AnalyticsDashboard({ results, systemStats }: AnalyticsDashboardP
                         </div>
                       </div>
                       <div className="flex justify-between items-center">
-                        <span className="text-purple-300">Medium (1-10MB)</span>
+                        <span className="text-purple-700">Medium (1-10MB)</span>
                         <div className="flex items-center gap-2">
-                          <div className="w-24 bg-purple-900/50 rounded-full h-2">
+                          <div className="w-24 bg-purple-50 rounded-full h-2">
                             <div
                               className="bg-purple-500 h-2 rounded-full"
                               style={{
@@ -292,9 +292,9 @@ export function AnalyticsDashboard({ results, systemStats }: AnalyticsDashboardP
                         </div>
                       </div>
                       <div className="flex justify-between items-center">
-                        <span className="text-purple-300">Large (&gt;10MB)</span>
+                        <span className="text-purple-700">Large (&gt;10MB)</span>
                         <div className="flex items-center gap-2">
-                          <div className="w-24 bg-purple-900/50 rounded-full h-2">
+                          <div className="w-24 bg-purple-50 rounded-full h-2">
                             <div
                               className="bg-orange-500 h-2 rounded-full"
                               style={{
@@ -312,7 +312,7 @@ export function AnalyticsDashboard({ results, systemStats }: AnalyticsDashboardP
             </TabsContent>
 
             <TabsContent value="filetypes" className="space-y-4">
-              <Card className="bg-purple-800/30 border-purple-600">
+              <Card className="bg-purple-50 border-purple-300">
                 <CardHeader>
                   <CardTitle className="text-white text-lg">Top File Types</CardTitle>
                 </CardHeader>
@@ -321,11 +321,11 @@ export function AnalyticsDashboard({ results, systemStats }: AnalyticsDashboardP
                     {getTopFileTypes().map(([type, count], index) => (
                       <div key={type} className="flex items-center justify-between">
                         <div className="flex items-center gap-3">
-                          <Badge className="bg-purple-700 text-purple-100">#{index + 1}</Badge>
-                          <span className="text-purple-300">{type}</span>
+                          <Badge className="bg-purple-500 text-purple-500">#{index + 1}</Badge>
+                          <span className="text-purple-700">{type}</span>
                         </div>
                         <div className="flex items-center gap-3">
-                          <div className="w-32 bg-purple-900/50 rounded-full h-2">
+                          <div className="w-32 bg-purple-50 rounded-full h-2">
                             <div
                               className="bg-purple-500 h-2 rounded-full"
                               style={{
@@ -343,24 +343,24 @@ export function AnalyticsDashboard({ results, systemStats }: AnalyticsDashboardP
             </TabsContent>
 
             <TabsContent value="performance" className="space-y-4">
-              <Card className="bg-purple-800/30 border-purple-600">
+              <Card className="bg-purple-50 border-purple-300">
                 <CardHeader>
                   <CardTitle className="text-white text-lg">Engine Performance</CardTitle>
                 </CardHeader>
                 <CardContent>
                   <div className="space-y-3">
                     {Object.entries(analytics.enginePerformance).map(([engine, stats]) => (
-                      <div key={engine} className="flex items-center justify-between p-3 bg-purple-900/30 rounded">
+                      <div key={engine} className="flex items-center justify-between p-3 bg-purple-50 rounded">
                         <div className="flex items-center gap-3">
-                          <FileText className="w-4 h-4 text-purple-400" />
-                          <span className="text-purple-300 capitalize">{engine} Engine</span>
+                          <FileText className="w-4 h-4 text-purple-600" />
+                          <span className="text-purple-700 capitalize">{engine} Engine</span>
                         </div>
                         <div className="flex items-center gap-4">
                           <div className="text-right">
                             <p className="text-white font-medium">{stats.avg.toFixed(3)}s</p>
-                            <p className="text-xs text-purple-400">{stats.count} scans</p>
+                            <p className="text-xs text-purple-600">{stats.count} scans</p>
                           </div>
-                          <Badge className="bg-purple-700">
+                          <Badge className="bg-purple-500">
                             {stats.avg < 0.5 ? "Fast" : stats.avg < 1.0 ? "Normal" : "Slow"}
                           </Badge>
                         </div>
@@ -373,24 +373,24 @@ export function AnalyticsDashboard({ results, systemStats }: AnalyticsDashboardP
 
             <TabsContent value="security" className="space-y-4">
               <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                <Card className="bg-purple-800/30 border-purple-600">
+                <Card className="bg-purple-50 border-purple-300">
                   <CardContent className="p-4 text-center">
                     <Shield className="w-8 h-8 text-green-400 mx-auto mb-2" />
-                    <p className="text-sm text-purple-300">Low Risk</p>
+                    <p className="text-sm text-purple-700">Low Risk</p>
                     <p className="text-2xl font-bold text-white">{analytics.threatLevels.low || 0}</p>
                   </CardContent>
                 </Card>
-                <Card className="bg-purple-800/30 border-purple-600">
+                <Card className="bg-purple-50 border-purple-300">
                   <CardContent className="p-4 text-center">
                     <AlertTriangle className="w-8 h-8 text-yellow-400 mx-auto mb-2" />
-                    <p className="text-sm text-purple-300">Medium Risk</p>
+                    <p className="text-sm text-purple-700">Medium Risk</p>
                     <p className="text-2xl font-bold text-white">{analytics.threatLevels.medium || 0}</p>
                   </CardContent>
                 </Card>
-                <Card className="bg-purple-800/30 border-purple-600">
+                <Card className="bg-purple-50 border-purple-300">
                   <CardContent className="p-4 text-center">
                     <AlertTriangle className="w-8 h-8 text-red-400 mx-auto mb-2" />
-                    <p className="text-sm text-purple-300">High Risk</p>
+                    <p className="text-sm text-purple-700">High Risk</p>
                     <p className="text-2xl font-bold text-white">{analytics.threatLevels.high || 0}</p>
                   </CardContent>
                 </Card>
@@ -398,27 +398,27 @@ export function AnalyticsDashboard({ results, systemStats }: AnalyticsDashboardP
             </TabsContent>
 
             <TabsContent value="trends" className="space-y-4">
-              <Card className="bg-purple-800/30 border-purple-600">
+              <Card className="bg-purple-50 border-purple-300">
                 <CardHeader>
                   <CardTitle className="text-white text-lg">Performance Trends</CardTitle>
                 </CardHeader>
                 <CardContent className="space-y-4">
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div className="p-4 bg-purple-900/30 rounded">
+                    <div className="p-4 bg-purple-50 rounded">
                       <div className="flex items-center gap-2 mb-2">
                         <TrendingUp className="w-4 h-4 text-green-400" />
                         <span className="text-green-400 font-medium">Scan Speed Improvement</span>
                       </div>
                       <p className="text-2xl font-bold text-white">+15%</p>
-                      <p className="text-xs text-purple-400">Compared to last month</p>
+                      <p className="text-xs text-purple-600">Compared to last month</p>
                     </div>
-                    <div className="p-4 bg-purple-900/30 rounded">
+                    <div className="p-4 bg-purple-50 rounded">
                       <div className="flex items-center gap-2 mb-2">
                         <TrendingUp className="w-4 h-4 text-green-400" />
                         <span className="text-green-400 font-medium">Detection Accuracy</span>
                       </div>
                       <p className="text-2xl font-bold text-white">+2.3%</p>
-                      <p className="text-xs text-purple-400">Confidence score improvement</p>
+                      <p className="text-xs text-purple-600">Confidence score improvement</p>
                     </div>
                   </div>
                 </CardContent>

--- a/components/api-explorer.tsx
+++ b/components/api-explorer.tsx
@@ -139,19 +139,19 @@ export function APIExplorer({ config }: APIExplorerProps) {
 
   return (
     <div className="space-y-6">
-      <Card className="bg-purple-900/30 border-purple-700">
+      <Card className="bg-purple-50 border-purple-300">
         <CardHeader>
           <CardTitle className="text-white flex items-center gap-2">
             <Code className="w-5 h-5" />
             Probium API Explorer
           </CardTitle>
-          <CardDescription className="text-purple-300">
+          <CardDescription className="text-purple-700">
             Interactive API documentation and testing interface
           </CardDescription>
         </CardHeader>
         <CardContent>
           <Tabs defaultValue="endpoints" className="space-y-4">
-            <TabsList className="grid w-full grid-cols-4 bg-purple-800/50">
+            <TabsList className="grid w-full grid-cols-4 bg-purple-100">
               <TabsTrigger value="endpoints">Endpoints</TabsTrigger>
               <TabsTrigger value="examples">Examples</TabsTrigger>
               <TabsTrigger value="sdk">SDK</TabsTrigger>
@@ -160,18 +160,18 @@ export function APIExplorer({ config }: APIExplorerProps) {
 
             <TabsContent value="endpoints" className="space-y-4">
               <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                <Card className="bg-purple-800/30 border-purple-600">
+                <Card className="bg-purple-50 border-purple-300">
                   <CardHeader>
                     <CardTitle className="text-white text-lg">API Request</CardTitle>
                   </CardHeader>
                   <CardContent className="space-y-4">
                     <div className="space-y-2">
-                      <label className="text-purple-300 text-sm">Endpoint</label>
+                      <label className="text-purple-700 text-sm">Endpoint</label>
                       <Select value={selectedEndpoint} onValueChange={setSelectedEndpoint}>
-                        <SelectTrigger className="bg-purple-900/50 border-purple-600 text-white">
+                        <SelectTrigger className="bg-purple-50 border-purple-300 text-white">
                           <SelectValue />
                         </SelectTrigger>
-                        <SelectContent className="bg-purple-800 border-purple-600">
+                        <SelectContent className="bg-purple-200 border-purple-300">
                           {Object.entries(apiEndpoints).map(([key, endpoint]) => (
                             <SelectItem key={key} value={key} className="text-white">
                               <div className="flex items-center gap-2">
@@ -189,26 +189,26 @@ export function APIExplorer({ config }: APIExplorerProps) {
                     </div>
 
                     <div className="space-y-2">
-                      <label className="text-purple-300 text-sm">Request Body</label>
+                      <label className="text-purple-700 text-sm">Request Body</label>
                       <Textarea
                         value={
                           requestBody ||
                           JSON.stringify(apiEndpoints[selectedEndpoint as keyof typeof apiEndpoints].example, null, 2)
                         }
                         onChange={(e) => setRequestBody(e.target.value)}
-                        className="bg-purple-900/50 border-purple-600 text-white font-mono text-sm"
+                        className="bg-purple-50 border-purple-300 text-white font-mono text-sm"
                         rows={10}
                       />
                     </div>
 
-                    <Button onClick={executeRequest} className="w-full bg-purple-600 hover:bg-purple-700">
+                    <Button onClick={executeRequest} className="w-full bg-purple-400 hover:bg-purple-500">
                       <Play className="w-4 h-4 mr-2" />
                       Execute Request
                     </Button>
                   </CardContent>
                 </Card>
 
-                <Card className="bg-purple-800/30 border-purple-600">
+                <Card className="bg-purple-50 border-purple-300">
                   <CardHeader>
                     <CardTitle className="text-white text-lg flex items-center justify-between">
                       API Response
@@ -216,7 +216,7 @@ export function APIExplorer({ config }: APIExplorerProps) {
                         variant="ghost"
                         size="sm"
                         onClick={() => copyToClipboard(response)}
-                        className="text-purple-300"
+                        className="text-purple-700"
                       >
                         <Copy className="w-4 h-4" />
                       </Button>
@@ -226,12 +226,12 @@ export function APIExplorer({ config }: APIExplorerProps) {
                     <div className="space-y-2">
                       <div className="flex items-center gap-2">
                         <Badge className="bg-green-700">200 OK</Badge>
-                        <span className="text-purple-300 text-sm">application/json</span>
+                        <span className="text-purple-700 text-sm">application/json</span>
                       </div>
                       <Textarea
                         value={response}
                         readOnly
-                        className="bg-purple-900/50 border-purple-600 text-white font-mono text-sm"
+                        className="bg-purple-50 border-purple-300 text-white font-mono text-sm"
                         rows={15}
                       />
                     </div>
@@ -239,7 +239,7 @@ export function APIExplorer({ config }: APIExplorerProps) {
                 </Card>
               </div>
 
-              <Card className="bg-purple-800/30 border-purple-600">
+              <Card className="bg-purple-50 border-purple-300">
                 <CardHeader>
                   <CardTitle className="text-white text-lg">Endpoint Details</CardTitle>
                 </CardHeader>
@@ -251,11 +251,11 @@ export function APIExplorer({ config }: APIExplorerProps) {
                       >
                         {apiEndpoints[selectedEndpoint as keyof typeof apiEndpoints].method}
                       </Badge>
-                      <code className="text-purple-300 bg-purple-900/50 px-2 py-1 rounded">
+                      <code className="text-purple-700 bg-purple-50 px-2 py-1 rounded">
                         {apiEndpoints[selectedEndpoint as keyof typeof apiEndpoints].path}
                       </code>
                     </div>
-                    <p className="text-purple-200">
+                    <p className="text-purple-600">
                       {apiEndpoints[selectedEndpoint as keyof typeof apiEndpoints].description}
                     </p>
                   </div>
@@ -265,12 +265,12 @@ export function APIExplorer({ config }: APIExplorerProps) {
 
             <TabsContent value="examples" className="space-y-4">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <Card className="bg-purple-800/30 border-purple-600">
+                <Card className="bg-purple-50 border-purple-300">
                   <CardHeader>
                     <CardTitle className="text-white text-lg">Python Example</CardTitle>
                   </CardHeader>
                   <CardContent>
-                    <pre className="text-sm text-purple-200 bg-purple-900/50 p-4 rounded overflow-x-auto">
+                    <pre className="text-sm text-purple-600 bg-purple-50 p-4 rounded overflow-x-auto">
                       {`import requests
 import json
 
@@ -299,12 +299,12 @@ print(f"Confidence: {result['result']['confidence']}")
                   </CardContent>
                 </Card>
 
-                <Card className="bg-purple-800/30 border-purple-600">
+                <Card className="bg-purple-50 border-purple-300">
                   <CardHeader>
                     <CardTitle className="text-white text-lg">cURL Example</CardTitle>
                   </CardHeader>
                   <CardContent>
-                    <pre className="text-sm text-purple-200 bg-purple-900/50 p-4 rounded overflow-x-auto">
+                    <pre className="text-sm text-purple-600 bg-purple-50 p-4 rounded overflow-x-auto">
                       {`curl -X POST \\
   http://localhost:8000/api/v1/scan/file \\
   -H "Content-Type: multipart/form-data" \\
@@ -319,12 +319,12 @@ print(f"Confidence: {result['result']['confidence']}")
                   </CardContent>
                 </Card>
 
-                <Card className="bg-purple-800/30 border-purple-600">
+                <Card className="bg-purple-50 border-purple-300">
                   <CardHeader>
                     <CardTitle className="text-white text-lg">JavaScript Example</CardTitle>
                   </CardHeader>
                   <CardContent>
-                    <pre className="text-sm text-purple-200 bg-purple-900/50 p-4 rounded overflow-x-auto">
+                    <pre className="text-sm text-purple-600 bg-purple-50 p-4 rounded overflow-x-auto">
                       {`const formData = new FormData();
 formData.append('file', fileInput.files[0]);
 formData.append('engines', 'pdf,binary');
@@ -347,12 +347,12 @@ fetch('/api/v1/scan/file', {
                   </CardContent>
                 </Card>
 
-                <Card className="bg-purple-800/30 border-purple-600">
+                <Card className="bg-purple-50 border-purple-300">
                   <CardHeader>
                     <CardTitle className="text-white text-lg">Go Example</CardTitle>
                   </CardHeader>
                   <CardContent>
-                    <pre className="text-sm text-purple-200 bg-purple-900/50 p-4 rounded overflow-x-auto">
+                    <pre className="text-sm text-purple-600 bg-purple-50 p-4 rounded overflow-x-auto">
                       {`package main
 
 import (
@@ -393,7 +393,7 @@ func main() {
             </TabsContent>
 
             <TabsContent value="sdk" className="space-y-4">
-              <Card className="bg-purple-800/30 border-purple-600">
+              <Card className="bg-purple-50 border-purple-300">
                 <CardHeader>
                   <CardTitle className="text-white text-lg flex items-center gap-2">
                     <Download className="w-5 h-5" />
@@ -402,35 +402,35 @@ func main() {
                 </CardHeader>
                 <CardContent className="space-y-4">
                   <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                    <div className="p-4 bg-purple-900/30 rounded border border-purple-600">
+                    <div className="p-4 bg-purple-50 rounded border border-purple-300">
                       <h3 className="text-white font-medium mb-2">Python SDK</h3>
-                      <p className="text-purple-300 text-sm mb-3">Official Python client library</p>
-                      <code className="text-xs text-purple-200 bg-purple-900/50 px-2 py-1 rounded block mb-2">
+                      <p className="text-purple-700 text-sm mb-3">Official Python client library</p>
+                      <code className="text-xs text-purple-600 bg-purple-50 px-2 py-1 rounded block mb-2">
                         pip install probium-client
                       </code>
-                      <Button size="sm" className="w-full bg-purple-600 hover:bg-purple-700">
+                      <Button size="sm" className="w-full bg-purple-400 hover:bg-purple-500">
                         Download
                       </Button>
                     </div>
 
-                    <div className="p-4 bg-purple-900/30 rounded border border-purple-600">
+                    <div className="p-4 bg-purple-50 rounded border border-purple-300">
                       <h3 className="text-white font-medium mb-2">Node.js SDK</h3>
-                      <p className="text-purple-300 text-sm mb-3">JavaScript/TypeScript client</p>
-                      <code className="text-xs text-purple-200 bg-purple-900/50 px-2 py-1 rounded block mb-2">
+                      <p className="text-purple-700 text-sm mb-3">JavaScript/TypeScript client</p>
+                      <code className="text-xs text-purple-600 bg-purple-50 px-2 py-1 rounded block mb-2">
                         npm install @probium/client
                       </code>
-                      <Button size="sm" className="w-full bg-purple-600 hover:bg-purple-700">
+                      <Button size="sm" className="w-full bg-purple-400 hover:bg-purple-500">
                         Download
                       </Button>
                     </div>
 
-                    <div className="p-4 bg-purple-900/30 rounded border border-purple-600">
+                    <div className="p-4 bg-purple-50 rounded border border-purple-300">
                       <h3 className="text-white font-medium mb-2">Go SDK</h3>
-                      <p className="text-purple-300 text-sm mb-3">Go client library</p>
-                      <code className="text-xs text-purple-200 bg-purple-900/50 px-2 py-1 rounded block mb-2">
+                      <p className="text-purple-700 text-sm mb-3">Go client library</p>
+                      <code className="text-xs text-purple-600 bg-purple-50 px-2 py-1 rounded block mb-2">
                         go get github.com/probium/go-client
                       </code>
-                      <Button size="sm" className="w-full bg-purple-600 hover:bg-purple-700">
+                      <Button size="sm" className="w-full bg-purple-400 hover:bg-purple-500">
                         Download
                       </Button>
                     </div>
@@ -440,7 +440,7 @@ func main() {
             </TabsContent>
 
             <TabsContent value="docs" className="space-y-4">
-              <Card className="bg-purple-800/30 border-purple-600">
+              <Card className="bg-purple-50 border-purple-300">
                 <CardHeader>
                   <CardTitle className="text-white text-lg flex items-center gap-2">
                     <FileText className="w-5 h-5" />
@@ -449,30 +449,30 @@ func main() {
                 </CardHeader>
                 <CardContent className="space-y-4">
                   <div className="space-y-3">
-                    <div className="p-3 bg-purple-900/30 rounded border border-purple-600">
+                    <div className="p-3 bg-purple-50 rounded border border-purple-300">
                       <h3 className="text-white font-medium">Authentication</h3>
-                      <p className="text-purple-300 text-sm">
+                      <p className="text-purple-700 text-sm">
                         API uses Bearer token authentication. Include your API key in the Authorization header.
                       </p>
                     </div>
 
-                    <div className="p-3 bg-purple-900/30 rounded border border-purple-600">
+                    <div className="p-3 bg-purple-50 rounded border border-purple-300">
                       <h3 className="text-white font-medium">Rate Limiting</h3>
-                      <p className="text-purple-300 text-sm">
+                      <p className="text-purple-700 text-sm">
                         API requests are limited to 1000 requests per hour per API key.
                       </p>
                     </div>
 
-                    <div className="p-3 bg-purple-900/30 rounded border border-purple-600">
+                    <div className="p-3 bg-purple-50 rounded border border-purple-300">
                       <h3 className="text-white font-medium">Error Handling</h3>
-                      <p className="text-purple-300 text-sm">
+                      <p className="text-purple-700 text-sm">
                         API returns standard HTTP status codes. Error details are included in the response body.
                       </p>
                     </div>
 
-                    <div className="p-3 bg-purple-900/30 rounded border border-purple-600">
+                    <div className="p-3 bg-purple-50 rounded border border-purple-300">
                       <h3 className="text-white font-medium">Webhooks</h3>
-                      <p className="text-purple-300 text-sm">
+                      <p className="text-purple-700 text-sm">
                         Configure webhooks to receive real-time notifications about scan results.
                       </p>
                     </div>

--- a/components/batch-processor.tsx
+++ b/components/batch-processor.tsx
@@ -93,31 +93,31 @@ export function BatchProcessor({ onBatchComplete, config, setIsScanning }: Batch
     <div className="space-y-6">
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Batch Upload */}
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardHeader>
             <CardTitle className="text-white flex items-center gap-2">
               <Files className="w-5 h-5" />
               Batch File Upload
             </CardTitle>
-            <CardDescription className="text-purple-300">Upload multiple files for parallel processing</CardDescription>
+            <CardDescription className="text-purple-700">Upload multiple files for parallel processing</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <div
               {...getRootProps()}
               className={`border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-all ${
                 isDragActive
-                  ? "border-purple-400 bg-purple-800/30"
-                  : "border-purple-600 hover:border-purple-500 bg-purple-900/20"
+                  ? "border-purple-200 bg-purple-50"
+                  : "border-purple-300 hover:border-purple-300 bg-purple-50"
               }`}
             >
               <input {...getInputProps()} />
-              <Files className="w-12 h-12 text-purple-400 mx-auto mb-4" />
+              <Files className="w-12 h-12 text-purple-600 mx-auto mb-4" />
               {isDragActive ? (
-                <p className="text-purple-300">Drop the files here...</p>
+                <p className="text-purple-700">Drop the files here...</p>
               ) : (
                 <div>
-                  <p className="text-purple-200 mb-2">Drag & drop multiple files here, or click to select</p>
-                  <p className="text-sm text-purple-400">Process up to 1000 files simultaneously</p>
+                  <p className="text-purple-600 mb-2">Drag & drop multiple files here, or click to select</p>
+                  <p className="text-sm text-purple-600">Process up to 1000 files simultaneously</p>
                 </div>
               )}
             </div>
@@ -125,25 +125,25 @@ export function BatchProcessor({ onBatchComplete, config, setIsScanning }: Batch
             {files.length > 0 && (
               <div className="space-y-3">
                 <div className="flex items-center justify-between">
-                  <span className="text-purple-300">{files.length} files queued</span>
+                  <span className="text-purple-700">{files.length} files queued</span>
                   <Button
                     onClick={clearFiles}
                     variant="outline"
                     size="sm"
-                    className="border-purple-600 text-purple-300 bg-transparent"
+                    className="border-purple-300 text-purple-700 bg-transparent"
                   >
                     Clear All
                   </Button>
                 </div>
                 <div className="max-h-40 overflow-y-auto space-y-1">
                   {files.slice(0, 10).map((file, index) => (
-                    <div key={index} className="flex items-center justify-between p-2 bg-purple-800/30 rounded text-sm">
-                      <span className="text-purple-200 truncate">{file.name}</span>
-                      <span className="text-purple-400">{(file.size / 1024 / 1024).toFixed(1)}MB</span>
+                    <div key={index} className="flex items-center justify-between p-2 bg-purple-50 rounded text-sm">
+                      <span className="text-purple-600 truncate">{file.name}</span>
+                      <span className="text-purple-600">{(file.size / 1024 / 1024).toFixed(1)}MB</span>
                     </div>
                   ))}
                   {files.length > 10 && (
-                    <p className="text-center text-purple-400 text-sm">...and {files.length - 10} more files</p>
+                    <p className="text-center text-purple-600 text-sm">...and {files.length - 10} more files</p>
                   )}
                 </div>
               </div>
@@ -152,7 +152,7 @@ export function BatchProcessor({ onBatchComplete, config, setIsScanning }: Batch
         </Card>
 
         {/* Batch Options */}
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardHeader>
             <CardTitle className="text-white flex items-center gap-2">
               <Database className="w-5 h-5" />
@@ -164,7 +164,7 @@ export function BatchProcessor({ onBatchComplete, config, setIsScanning }: Batch
               <div className="flex items-center justify-between">
                 <div>
                   <Label className="text-white">Parallel Processing</Label>
-                  <p className="text-xs text-purple-400">Use multiple threads for faster processing</p>
+                  <p className="text-xs text-purple-600">Use multiple threads for faster processing</p>
                 </div>
                 <Switch
                   checked={batchOptions.parallelProcessing}
@@ -175,7 +175,7 @@ export function BatchProcessor({ onBatchComplete, config, setIsScanning }: Batch
               <div className="flex items-center justify-between">
                 <div>
                   <Label className="text-white">Skip Duplicates</Label>
-                  <p className="text-xs text-purple-400">Skip files with identical hashes</p>
+                  <p className="text-xs text-purple-600">Skip files with identical hashes</p>
                 </div>
                 <Switch
                   checked={batchOptions.skipDuplicates}
@@ -186,7 +186,7 @@ export function BatchProcessor({ onBatchComplete, config, setIsScanning }: Batch
               <div className="flex items-center justify-between">
                 <div>
                   <Label className="text-white">Generate Report</Label>
-                  <p className="text-xs text-purple-400">Create detailed batch processing report</p>
+                  <p className="text-xs text-purple-600">Create detailed batch processing report</p>
                 </div>
                 <Switch
                   checked={batchOptions.generateReport}
@@ -197,7 +197,7 @@ export function BatchProcessor({ onBatchComplete, config, setIsScanning }: Batch
               <div className="flex items-center justify-between">
                 <div>
                   <Label className="text-white">Auto Export</Label>
-                  <p className="text-xs text-purple-400">Automatically export results when complete</p>
+                  <p className="text-xs text-purple-600">Automatically export results when complete</p>
                 </div>
                 <Switch
                   checked={batchOptions.autoExport}
@@ -206,12 +206,12 @@ export function BatchProcessor({ onBatchComplete, config, setIsScanning }: Batch
               </div>
             </div>
 
-            <div className="pt-4 border-t border-purple-700">
+            <div className="pt-4 border-t border-purple-300">
               <div className="flex gap-2">
                 <Button
                   onClick={startBatchProcessing}
                   disabled={batchStatus === "running" || files.length === 0}
-                  className="flex-1 bg-purple-600 hover:bg-purple-700"
+                  className="flex-1 bg-purple-400 hover:bg-purple-500"
                 >
                   <Play className="w-4 h-4 mr-2" />
                   Start Batch
@@ -220,7 +220,7 @@ export function BatchProcessor({ onBatchComplete, config, setIsScanning }: Batch
                   <Button
                     onClick={() => setBatchStatus("paused")}
                     variant="outline"
-                    className="border-purple-600 text-purple-300"
+                    className="border-purple-300 text-purple-700"
                   >
                     <Pause className="w-4 h-4" />
                   </Button>
@@ -233,17 +233,17 @@ export function BatchProcessor({ onBatchComplete, config, setIsScanning }: Batch
 
       {/* Batch Progress */}
       {batchStatus === "running" && (
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardContent className="p-6">
             <div className="space-y-4">
               <div className="flex justify-between items-center">
                 <h3 className="font-semibold text-white">Batch Processing Progress</h3>
                 <div className="flex items-center gap-4">
-                  <Badge className="bg-purple-700">
+                  <Badge className="bg-purple-500">
                     <Cpu className="w-3 h-3 mr-1" />
                     {config.threadPool} threads
                   </Badge>
-                  <Badge className="bg-purple-700">
+                  <Badge className="bg-purple-500">
                     <Clock className="w-3 h-3 mr-1" />
                     {Math.round((Date.now() - (Date.now() - processedCount * 800)) / 1000)}s
                   </Badge>
@@ -252,16 +252,16 @@ export function BatchProcessor({ onBatchComplete, config, setIsScanning }: Batch
 
               <div className="space-y-2">
                 <div className="flex justify-between text-sm">
-                  <span className="text-purple-300">
+                  <span className="text-purple-700">
                     Progress: {processedCount} / {files.length}
                   </span>
-                  <span className="text-purple-300">{Math.round((processedCount / files.length) * 100)}%</span>
+                  <span className="text-purple-700">{Math.round((processedCount / files.length) * 100)}%</span>
                 </div>
-                <Progress value={(processedCount / files.length) * 100} className="bg-purple-800" />
+                <Progress value={(processedCount / files.length) * 100} className="bg-purple-200" />
               </div>
 
               {currentFile && (
-                <p className="text-sm text-purple-300">
+                <p className="text-sm text-purple-700">
                   Currently processing: <span className="font-medium text-white">{currentFile}</span>
                 </p>
               )}

--- a/components/configuration-panel.tsx
+++ b/components/configuration-panel.tsx
@@ -39,13 +39,13 @@ export function ConfigurationPanel({ config, onConfigChange }: ConfigurationPane
 
   return (
     <div className="space-y-6">
-      <Card className="bg-purple-900/30 border-purple-700">
+      <Card className="bg-purple-50 border-purple-300">
         <CardHeader>
           <div className="flex items-center gap-3">
-            <Settings className="w-6 h-6 text-purple-400" />
+            <Settings className="w-6 h-6 text-purple-600" />
             <div>
               <CardTitle className="text-white">Probium Configuration</CardTitle>
-              <CardDescription className="text-purple-300">
+              <CardDescription className="text-purple-700">
                 Configure detection engines, performance settings, and advanced options
               </CardDescription>
             </div>
@@ -53,7 +53,7 @@ export function ConfigurationPanel({ config, onConfigChange }: ConfigurationPane
         </CardHeader>
         <CardContent>
           <Tabs defaultValue="engines" className="space-y-4">
-            <TabsList className="grid w-full grid-cols-4 bg-purple-800/50">
+            <TabsList className="grid w-full grid-cols-4 bg-purple-100">
               <TabsTrigger value="engines">Engines</TabsTrigger>
               <TabsTrigger value="performance">Performance</TabsTrigger>
               <TabsTrigger value="security">Security</TabsTrigger>
@@ -61,13 +61,13 @@ export function ConfigurationPanel({ config, onConfigChange }: ConfigurationPane
             </TabsList>
 
             <TabsContent value="engines" className="space-y-4">
-              <Card className="bg-purple-800/30 border-purple-600">
+              <Card className="bg-purple-50 border-purple-300">
                 <CardHeader>
                   <CardTitle className="text-white text-lg flex items-center gap-2">
                     <Shield className="w-5 h-5" />
                     Detection Engines
                   </CardTitle>
-                  <CardDescription className="text-purple-300">
+                  <CardDescription className="text-purple-700">
                     Select which file type detection engines to use during scanning
                   </CardDescription>
                 </CardHeader>
@@ -102,7 +102,7 @@ export function ConfigurationPanel({ config, onConfigChange }: ConfigurationPane
                         id: "binary",
                         name: "Binary Engine",
                         description: "Binary file analysis",
-                        color: "text-purple-400",
+                        color: "text-purple-600",
                       },
                       {
                         id: "text",
@@ -125,7 +125,7 @@ export function ConfigurationPanel({ config, onConfigChange }: ConfigurationPane
                     ].map((engine) => (
                       <div
                         key={engine.id}
-                        className="flex items-center space-x-3 p-3 border border-purple-600 rounded-lg bg-purple-900/20"
+                        className="flex items-center space-x-3 p-3 border border-purple-300 rounded-lg bg-purple-50"
                       >
                         <Switch
                           checked={config.engines.includes(engine.id)}
@@ -138,16 +138,16 @@ export function ConfigurationPanel({ config, onConfigChange }: ConfigurationPane
                         />
                         <div className="flex-1">
                           <Label className={`font-medium ${engine.color}`}>{engine.name}</Label>
-                          <p className="text-sm text-purple-400">{engine.description}</p>
+                          <p className="text-sm text-purple-600">{engine.description}</p>
                         </div>
                       </div>
                     ))}
                   </div>
 
                   <div className="flex items-center gap-2 pt-2">
-                    <span className="text-sm font-medium text-purple-300">Active engines:</span>
+                    <span className="text-sm font-medium text-purple-700">Active engines:</span>
                     {config.engines.map((engine: string) => (
-                      <Badge key={engine} variant="secondary" className="bg-purple-700 text-purple-100">
+                      <Badge key={engine} variant="secondary" className="bg-purple-500 text-purple-500">
                         {engine}
                       </Badge>
                     ))}
@@ -157,13 +157,13 @@ export function ConfigurationPanel({ config, onConfigChange }: ConfigurationPane
             </TabsContent>
 
             <TabsContent value="performance" className="space-y-4">
-              <Card className="bg-purple-800/30 border-purple-600">
+              <Card className="bg-purple-50 border-purple-300">
                 <CardHeader>
                   <CardTitle className="text-white text-lg flex items-center gap-2">
                     <Cpu className="w-5 h-5" />
                     Performance Settings
                   </CardTitle>
-                  <CardDescription className="text-purple-300">
+                  <CardDescription className="text-purple-700">
                     Configure parallel processing and performance parameters
                   </CardDescription>
                 </CardHeader>
@@ -171,7 +171,7 @@ export function ConfigurationPanel({ config, onConfigChange }: ConfigurationPane
                   <div className="space-y-3">
                     <div className="flex items-center justify-between">
                       <Label className="text-white">Thread Pool Size</Label>
-                      <Badge variant="outline" className="border-purple-600 text-purple-300">
+                      <Badge variant="outline" className="border-purple-300 text-purple-700">
                         {config.threadPool} threads
                       </Badge>
                     </div>
@@ -183,7 +183,7 @@ export function ConfigurationPanel({ config, onConfigChange }: ConfigurationPane
                       step={1}
                       className="w-full"
                     />
-                    <p className="text-sm text-purple-400">
+                    <p className="text-sm text-purple-600">
                       Number of parallel threads for batch processing. Higher values may improve performance but use
                       more system resources.
                     </p>
@@ -192,7 +192,7 @@ export function ConfigurationPanel({ config, onConfigChange }: ConfigurationPane
                   <div className="space-y-3">
                     <div className="flex items-center justify-between">
                       <Label className="text-white">Confidence Threshold</Label>
-                      <Badge variant="outline" className="border-purple-600 text-purple-300">
+                      <Badge variant="outline" className="border-purple-300 text-purple-700">
                         {(config.confidenceThreshold * 100).toFixed(0)}%
                       </Badge>
                     </div>
@@ -204,7 +204,7 @@ export function ConfigurationPanel({ config, onConfigChange }: ConfigurationPane
                       step={0.05}
                       className="w-full"
                     />
-                    <p className="text-sm text-purple-400">
+                    <p className="text-sm text-purple-600">
                       Minimum confidence level required for file type detection. Lower values may detect more files but
                       with less certainty.
                     </p>
@@ -213,7 +213,7 @@ export function ConfigurationPanel({ config, onConfigChange }: ConfigurationPane
                   <div className="space-y-3">
                     <div className="flex items-center justify-between">
                       <Label className="text-white">Max File Size</Label>
-                      <Badge variant="outline" className="border-purple-600 text-purple-300">
+                      <Badge variant="outline" className="border-purple-300 text-purple-700">
                         {(config.maxFileSize / 1024 / 1024).toFixed(0)} MB
                       </Badge>
                     </div>
@@ -225,7 +225,7 @@ export function ConfigurationPanel({ config, onConfigChange }: ConfigurationPane
                       step={10}
                       className="w-full"
                     />
-                    <p className="text-sm text-purple-400">
+                    <p className="text-sm text-purple-600">
                       Maximum file size that can be processed. Larger files may require more memory and processing time.
                     </p>
                   </div>
@@ -233,7 +233,7 @@ export function ConfigurationPanel({ config, onConfigChange }: ConfigurationPane
                   <div className="space-y-3">
                     <div className="flex items-center justify-between">
                       <Label className="text-white">Timeout</Label>
-                      <Badge variant="outline" className="border-purple-600 text-purple-300">
+                      <Badge variant="outline" className="border-purple-300 text-purple-700">
                         {(config.timeout / 1000).toFixed(0)}s
                       </Badge>
                     </div>
@@ -245,7 +245,7 @@ export function ConfigurationPanel({ config, onConfigChange }: ConfigurationPane
                       step={5}
                       className="w-full"
                     />
-                    <p className="text-sm text-purple-400">
+                    <p className="text-sm text-purple-600">
                       Maximum time allowed for file processing before timeout. Increase for large or complex files.
                     </p>
                   </div>
@@ -254,7 +254,7 @@ export function ConfigurationPanel({ config, onConfigChange }: ConfigurationPane
             </TabsContent>
 
             <TabsContent value="security" className="space-y-4">
-              <Card className="bg-purple-800/30 border-purple-600">
+              <Card className="bg-purple-50 border-purple-300">
                 <CardHeader>
                   <CardTitle className="text-white text-lg flex items-center gap-2">
                     <Shield className="w-5 h-5" />
@@ -265,7 +265,7 @@ export function ConfigurationPanel({ config, onConfigChange }: ConfigurationPane
                   <div className="flex items-center justify-between">
                     <div>
                       <Label className="text-white">Enable Hashing</Label>
-                      <p className="text-sm text-purple-400">Generate MD5, SHA1, SHA256, and CRC32 hashes</p>
+                      <p className="text-sm text-purple-600">Generate MD5, SHA1, SHA256, and CRC32 hashes</p>
                     </div>
                     <Switch
                       checked={config.enableHashing}
@@ -276,7 +276,7 @@ export function ConfigurationPanel({ config, onConfigChange }: ConfigurationPane
                   <div className="flex items-center justify-between">
                     <div>
                       <Label className="text-white">Metadata Extraction</Label>
-                      <p className="text-sm text-purple-400">Extract file metadata and properties</p>
+                      <p className="text-sm text-purple-600">Extract file metadata and properties</p>
                     </div>
                     <Switch
                       checked={config.enableMetadata}
@@ -287,7 +287,7 @@ export function ConfigurationPanel({ config, onConfigChange }: ConfigurationPane
                   <div className="flex items-center justify-between">
                     <div>
                       <Label className="text-white">Signature Validation</Label>
-                      <p className="text-sm text-purple-400">Validate digital signatures and certificates</p>
+                      <p className="text-sm text-purple-600">Validate digital signatures and certificates</p>
                     </div>
                     <Switch
                       checked={config.enableSignatureValidation}
@@ -298,7 +298,7 @@ export function ConfigurationPanel({ config, onConfigChange }: ConfigurationPane
                   <div className="flex items-center justify-between">
                     <div>
                       <Label className="text-white">Deep Analysis</Label>
-                      <p className="text-sm text-purple-400">
+                      <p className="text-sm text-purple-600">
                         Perform thorough content analysis and structure validation
                       </p>
                     </div>
@@ -312,7 +312,7 @@ export function ConfigurationPanel({ config, onConfigChange }: ConfigurationPane
             </TabsContent>
 
             <TabsContent value="advanced" className="space-y-4">
-              <Card className="bg-purple-800/30 border-purple-600">
+              <Card className="bg-purple-50 border-purple-300">
                 <CardHeader>
                   <CardTitle className="text-white text-lg flex items-center gap-2">
                     <Zap className="w-5 h-5" />
@@ -323,7 +323,7 @@ export function ConfigurationPanel({ config, onConfigChange }: ConfigurationPane
                   <div className="flex items-center justify-between">
                     <div>
                       <Label className="text-white">Cache Results</Label>
-                      <p className="text-sm text-purple-400">Cache scan results for faster re-scanning</p>
+                      <p className="text-sm text-purple-600">Cache scan results for faster re-scanning</p>
                     </div>
                     <Switch
                       checked={config.cacheResults}
@@ -334,7 +334,7 @@ export function ConfigurationPanel({ config, onConfigChange }: ConfigurationPane
                   <div className="flex items-center justify-between">
                     <div>
                       <Label className="text-white">Verbose Logging</Label>
-                      <p className="text-sm text-purple-400">Enable detailed logging output</p>
+                      <p className="text-sm text-purple-600">Enable detailed logging output</p>
                     </div>
                     <Switch
                       checked={config.verboseLogging}
@@ -346,23 +346,23 @@ export function ConfigurationPanel({ config, onConfigChange }: ConfigurationPane
                     <Label className="text-white">Custom Engine Path</Label>
                     <Input
                       placeholder="/path/to/custom/engines"
-                      className="bg-purple-900/50 border-purple-600 text-white placeholder-purple-400"
+                      className="bg-purple-50 border-purple-300 text-white placeholder-purple-400"
                     />
-                    <p className="text-sm text-purple-400">Path to custom detection engines</p>
+                    <p className="text-sm text-purple-600">Path to custom detection engines</p>
                   </div>
 
                   <div className="space-y-2">
                     <Label className="text-white">Configuration Notes</Label>
                     <Textarea
                       placeholder="Add notes about this configuration..."
-                      className="bg-purple-900/50 border-purple-600 text-white placeholder-purple-400"
+                      className="bg-purple-50 border-purple-300 text-white placeholder-purple-400"
                       rows={3}
                     />
                   </div>
                 </CardContent>
               </Card>
 
-              <Card className="bg-purple-800/30 border-purple-600">
+              <Card className="bg-purple-50 border-purple-300">
                 <CardHeader>
                   <CardTitle className="text-white text-lg flex items-center gap-2">
                     <Database className="w-5 h-5" />
@@ -371,14 +371,14 @@ export function ConfigurationPanel({ config, onConfigChange }: ConfigurationPane
                 </CardHeader>
                 <CardContent className="space-y-4">
                   <div className="flex gap-2">
-                    <Button className="flex-1 bg-purple-600 hover:bg-purple-700">Save Configuration</Button>
-                    <Button variant="outline" className="flex-1 border-purple-600 text-purple-300 bg-transparent">
+                    <Button className="flex-1 bg-purple-400 hover:bg-purple-500">Save Configuration</Button>
+                    <Button variant="outline" className="flex-1 border-purple-300 text-purple-700 bg-transparent">
                       Load Configuration
                     </Button>
                   </div>
 
                   <div className="flex gap-2">
-                    <Button variant="outline" className="flex-1 border-purple-600 text-purple-300 bg-transparent">
+                    <Button variant="outline" className="flex-1 border-purple-300 text-purple-700 bg-transparent">
                       Export Settings
                     </Button>
                     <Button

--- a/components/engine-manager.tsx
+++ b/components/engine-manager.tsx
@@ -85,7 +85,7 @@ export function EngineManager({ config, onConfigChange }: EngineManagerProps) {
       capabilities: ["Hex Analysis", "Pattern Matching", "Entropy Calculation", "Signature Detection"],
       supportedFormats: ["BIN", "EXE", "DLL", "SO", "DYLIB"],
       icon: Binary,
-      color: "text-purple-400",
+      color: "text-purple-600",
     },
     text: {
       name: "Text Processing Engine",
@@ -153,24 +153,24 @@ export function EngineManager({ config, onConfigChange }: EngineManagerProps) {
     <div className="space-y-6">
       {/* Engine Overview */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardContent className="p-4">
             <div className="flex items-center gap-3">
-              <Cpu className="w-8 h-8 text-purple-400" />
+              <Cpu className="w-8 h-8 text-purple-600" />
               <div>
-                <p className="text-sm text-purple-300">Active Engines</p>
+                <p className="text-sm text-purple-700">Active Engines</p>
                 <p className="text-2xl font-bold text-white">{config.engines.length}</p>
               </div>
             </div>
           </CardContent>
         </Card>
 
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardContent className="p-4">
             <div className="flex items-center gap-3">
               <Activity className="w-8 h-8 text-green-400" />
               <div>
-                <p className="text-sm text-purple-300">Avg Performance</p>
+                <p className="text-sm text-purple-700">Avg Performance</p>
                 <p className="text-2xl font-bold text-white">
                   {Math.round(
                     Object.values(engineStats).reduce((sum: number, stat: any) => sum + stat.performance, 0) /
@@ -183,12 +183,12 @@ export function EngineManager({ config, onConfigChange }: EngineManagerProps) {
           </CardContent>
         </Card>
 
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardContent className="p-4">
             <div className="flex items-center gap-3">
               <BarChart3 className="w-8 h-8 text-blue-400" />
               <div>
-                <p className="text-sm text-purple-300">Total Scans</p>
+                <p className="text-sm text-purple-700">Total Scans</p>
                 <p className="text-2xl font-bold text-white">
                   {Object.values(engineStats)
                     .reduce((sum: number, stat: any) => sum + stat.scansCompleted, 0)
@@ -199,12 +199,12 @@ export function EngineManager({ config, onConfigChange }: EngineManagerProps) {
           </CardContent>
         </Card>
 
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardContent className="p-4">
             <div className="flex items-center gap-3">
               <AlertTriangle className="w-8 h-8 text-yellow-400" />
               <div>
-                <p className="text-sm text-purple-300">Warnings</p>
+                <p className="text-sm text-purple-700">Warnings</p>
                 <p className="text-2xl font-bold text-white">
                   {Object.values(engineStats).filter((stat: any) => stat.status === "warning").length}
                 </p>
@@ -215,19 +215,19 @@ export function EngineManager({ config, onConfigChange }: EngineManagerProps) {
       </div>
 
       {/* Engine Management */}
-      <Card className="bg-purple-900/30 border-purple-700">
+      <Card className="bg-purple-50 border-purple-300">
         <CardHeader>
           <CardTitle className="text-white flex items-center gap-2">
             <Settings className="w-5 h-5" />
             Engine Configuration
           </CardTitle>
-          <CardDescription className="text-purple-300">
+          <CardDescription className="text-purple-700">
             Manage detection engines and their configurations
           </CardDescription>
         </CardHeader>
         <CardContent>
           <Tabs defaultValue="engines" className="space-y-4">
-            <TabsList className="grid w-full grid-cols-3 bg-purple-800/50">
+            <TabsList className="grid w-full grid-cols-3 bg-purple-100">
               <TabsTrigger value="engines">Engines</TabsTrigger>
               <TabsTrigger value="performance">Performance</TabsTrigger>
               <TabsTrigger value="advanced">Advanced</TabsTrigger>
@@ -241,14 +241,14 @@ export function EngineManager({ config, onConfigChange }: EngineManagerProps) {
                   const StatusIcon = getStatusIcon(stats.status)
 
                   return (
-                    <Card key={engineId} className="bg-purple-800/30 border-purple-600">
+                    <Card key={engineId} className="bg-purple-50 border-purple-300">
                       <CardContent className="p-4">
                         <div className="flex items-start justify-between mb-3">
                           <div className="flex items-center gap-3">
                             <IconComponent className={`w-6 h-6 ${details.color}`} />
                             <div>
                               <h3 className="font-semibold text-white">{details.name}</h3>
-                              <p className="text-xs text-purple-400">v{details.version}</p>
+                              <p className="text-xs text-purple-600">v{details.version}</p>
                             </div>
                           </div>
                           <div className="flex items-center gap-2">
@@ -260,35 +260,35 @@ export function EngineManager({ config, onConfigChange }: EngineManagerProps) {
                           </div>
                         </div>
 
-                        <p className="text-sm text-purple-300 mb-3">{details.description}</p>
+                        <p className="text-sm text-purple-700 mb-3">{details.description}</p>
 
                         <div className="space-y-2">
                           <div className="flex justify-between text-xs">
-                            <span className="text-purple-400">Performance</span>
+                            <span className="text-purple-600">Performance</span>
                             <span className="text-white">{stats.performance}%</span>
                           </div>
                           <Progress value={stats.performance} className="h-1" />
                         </div>
 
-                        <div className="mt-3 flex justify-between text-xs text-purple-400">
+                        <div className="mt-3 flex justify-between text-xs text-purple-600">
                           <span>Last used: {stats.lastUsed}</span>
                           <span>{stats.scansCompleted.toLocaleString()} scans</span>
                         </div>
 
                         <div className="mt-3">
-                          <p className="text-xs text-purple-400 mb-1">Supported Formats:</p>
+                          <p className="text-xs text-purple-600 mb-1">Supported Formats:</p>
                           <div className="flex flex-wrap gap-1">
                             {details.supportedFormats.slice(0, 3).map((format) => (
                               <Badge
                                 key={format}
                                 variant="outline"
-                                className="text-xs border-purple-600 text-purple-300"
+                                className="text-xs border-purple-300 text-purple-700"
                               >
                                 {format}
                               </Badge>
                             ))}
                             {details.supportedFormats.length > 3 && (
-                              <Badge variant="outline" className="text-xs border-purple-600 text-purple-300">
+                              <Badge variant="outline" className="text-xs border-purple-300 text-purple-700">
                                 +{details.supportedFormats.length - 3}
                               </Badge>
                             )}
@@ -303,7 +303,7 @@ export function EngineManager({ config, onConfigChange }: EngineManagerProps) {
 
             <TabsContent value="performance" className="space-y-4">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <Card className="bg-purple-800/30 border-purple-600">
+                <Card className="bg-purple-50 border-purple-300">
                   <CardHeader>
                     <CardTitle className="text-white text-lg">Engine Performance</CardTitle>
                   </CardHeader>
@@ -311,7 +311,7 @@ export function EngineManager({ config, onConfigChange }: EngineManagerProps) {
                     {Object.entries(engineStats).map(([engineId, stats]) => (
                       <div key={engineId} className="space-y-2">
                         <div className="flex justify-between">
-                          <span className="text-purple-300 capitalize">{engineId}</span>
+                          <span className="text-purple-700 capitalize">{engineId}</span>
                           <span className="text-white">{stats.performance}%</span>
                         </div>
                         <Progress value={stats.performance} className="h-2" />
@@ -320,17 +320,17 @@ export function EngineManager({ config, onConfigChange }: EngineManagerProps) {
                   </CardContent>
                 </Card>
 
-                <Card className="bg-purple-800/30 border-purple-600">
+                <Card className="bg-purple-50 border-purple-300">
                   <CardHeader>
                     <CardTitle className="text-white text-lg">Usage Statistics</CardTitle>
                   </CardHeader>
                   <CardContent className="space-y-4">
                     {Object.entries(engineStats).map(([engineId, stats]) => (
                       <div key={engineId} className="flex justify-between items-center">
-                        <span className="text-purple-300 capitalize">{engineId}</span>
+                        <span className="text-purple-700 capitalize">{engineId}</span>
                         <div className="text-right">
                           <p className="text-white font-medium">{stats.scansCompleted.toLocaleString()}</p>
-                          <p className="text-xs text-purple-400">{stats.lastUsed}</p>
+                          <p className="text-xs text-purple-600">{stats.lastUsed}</p>
                         </div>
                       </div>
                     ))}
@@ -341,52 +341,52 @@ export function EngineManager({ config, onConfigChange }: EngineManagerProps) {
 
             <TabsContent value="advanced" className="space-y-4">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <Card className="bg-purple-800/30 border-purple-600">
+                <Card className="bg-purple-50 border-purple-300">
                   <CardHeader>
                     <CardTitle className="text-white text-lg">Thread Pool Configuration</CardTitle>
                   </CardHeader>
                   <CardContent className="space-y-4">
                     <div className="space-y-2">
-                      <Label className="text-purple-300">Pool Size</Label>
+                      <Label className="text-purple-700">Pool Size</Label>
                       <Input
                         type="number"
                         value={config.threadPool}
                         onChange={(e) => onConfigChange({ ...config, threadPool: Number.parseInt(e.target.value) })}
-                        className="bg-purple-900/50 border-purple-600 text-white"
+                        className="bg-purple-50 border-purple-300 text-white"
                       />
                     </div>
 
                     <div className="space-y-2">
-                      <Label className="text-purple-300">Queue Size</Label>
+                      <Label className="text-purple-700">Queue Size</Label>
                       <Input
                         type="number"
                         defaultValue={100}
-                        className="bg-purple-900/50 border-purple-600 text-white"
+                        className="bg-purple-50 border-purple-300 text-white"
                       />
                     </div>
 
                     <div className="space-y-2">
-                      <Label className="text-purple-300">Timeout (ms)</Label>
+                      <Label className="text-purple-700">Timeout (ms)</Label>
                       <Input
                         type="number"
                         value={config.timeout}
-                        className="bg-purple-900/50 border-purple-600 text-white"
+                        className="bg-purple-50 border-purple-300 text-white"
                         readOnly
                       />
                     </div>
                   </CardContent>
                 </Card>
 
-                <Card className="bg-purple-800/30 border-purple-600">
+                <Card className="bg-purple-50 border-purple-300">
                   <CardHeader>
                     <CardTitle className="text-white text-lg">Engine Priorities</CardTitle>
                   </CardHeader>
                   <CardContent className="space-y-4">
                     <div className="space-y-3">
                       {config.engines.map((engine: string, index: number) => (
-                        <div key={engine} className="flex items-center justify-between p-2 bg-purple-900/30 rounded">
-                          <span className="text-purple-300 capitalize">{engine}</span>
-                          <Badge variant="outline" className="border-purple-600 text-purple-300">
+                        <div key={engine} className="flex items-center justify-between p-2 bg-purple-50 rounded">
+                          <span className="text-purple-700 capitalize">{engine}</span>
+                          <Badge variant="outline" className="border-purple-300 text-purple-700">
                             Priority {index + 1}
                           </Badge>
                         </div>

--- a/components/file-scanner.tsx
+++ b/components/file-scanner.tsx
@@ -110,13 +110,13 @@ export function FileScanner({ onScanComplete, config, setIsScanning }: FileScann
     <div className="space-y-6">
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* File Upload Section */}
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardHeader>
             <CardTitle className="text-white flex items-center gap-2">
               <Upload className="w-5 h-5" />
               File Upload & Analysis
             </CardTitle>
-            <CardDescription className="text-purple-300">
+            <CardDescription className="text-purple-700">
               Upload files for comprehensive analysis using Probium engines
             </CardDescription>
           </CardHeader>
@@ -126,18 +126,18 @@ export function FileScanner({ onScanComplete, config, setIsScanning }: FileScann
               {...getRootProps()}
               className={`border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-all ${
                 isDragActive
-                  ? "border-purple-400 bg-purple-800/30"
-                  : "border-purple-600 hover:border-purple-500 bg-purple-900/20"
+                  ? "border-purple-200 bg-purple-50"
+                  : "border-purple-300 hover:border-purple-300 bg-purple-50"
               }`}
             >
               <input {...getInputProps()} />
-              <Upload className="w-12 h-12 text-purple-400 mx-auto mb-4" />
+              <Upload className="w-12 h-12 text-purple-600 mx-auto mb-4" />
               {isDragActive ? (
-                <p className="text-purple-300">Drop the file here...</p>
+                <p className="text-purple-700">Drop the file here...</p>
               ) : (
                 <div>
-                  <p className="text-purple-200 mb-2">Drag & drop a file here, or click to select</p>
-                  <p className="text-sm text-purple-400">
+                  <p className="text-purple-600 mb-2">Drag & drop a file here, or click to select</p>
+                  <p className="text-sm text-purple-600">
                     Maximum file size: {(config.maxFileSize / 1024 / 1024).toFixed(0)}MB
                   </p>
                 </div>
@@ -146,18 +146,18 @@ export function FileScanner({ onScanComplete, config, setIsScanning }: FileScann
 
             {/* File Info */}
             {uploadedFile && (
-              <div className="flex items-center gap-3 p-4 bg-purple-800/30 rounded-lg border border-purple-700">
-                <FileText className="w-8 h-8 text-purple-400" />
+              <div className="flex items-center gap-3 p-4 bg-purple-50 rounded-lg border border-purple-300">
+                <FileText className="w-8 h-8 text-purple-600" />
                 <div className="flex-1">
                   <p className="font-medium text-white">{uploadedFile.name}</p>
-                  <p className="text-sm text-purple-300">
+                  <p className="text-sm text-purple-700">
                     {(uploadedFile.size / 1024 / 1024).toFixed(2)} MB • {uploadedFile.type || "Unknown type"}
                   </p>
                 </div>
                 <Button
                   onClick={performRealScan}
                   disabled={scanStatus === "scanning"}
-                  className="bg-purple-600 hover:bg-purple-700"
+                  className="bg-purple-400 hover:bg-purple-500"
                 >
                   {scanStatus === "scanning" ? "Scanning..." : "Analyze File"}
                 </Button>
@@ -168,11 +168,11 @@ export function FileScanner({ onScanComplete, config, setIsScanning }: FileScann
             {scanStatus === "scanning" && (
               <div className="space-y-3">
                 <div className="flex justify-between text-sm">
-                  <span className="text-purple-300">{currentStage}</span>
-                  <span className="text-purple-300">{Math.round(scanProgress)}%</span>
+                  <span className="text-purple-700">{currentStage}</span>
+                  <span className="text-purple-700">{Math.round(scanProgress)}%</span>
                 </div>
-                <Progress value={scanProgress} className="bg-purple-800" />
-                <div className="flex items-center gap-2 text-xs text-purple-400">
+                <Progress value={scanProgress} className="bg-purple-200" />
+                <div className="flex items-center gap-2 text-xs text-purple-600">
                   <Cpu className="w-3 h-3" />
                   <span>Using {config.engines.length} detection engines</span>
                 </div>
@@ -199,19 +199,19 @@ export function FileScanner({ onScanComplete, config, setIsScanning }: FileScann
         </Card>
 
         {/* Scan Options */}
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardHeader>
             <CardTitle className="text-white flex items-center gap-2">
               <Shield className="w-5 h-5" />
               Scan Configuration
             </CardTitle>
-            <CardDescription className="text-purple-300">
+            <CardDescription className="text-purple-700">
               Configure analysis options and detection engines
             </CardDescription>
           </CardHeader>
           <CardContent>
             <Tabs defaultValue="options" className="space-y-4">
-              <TabsList className="grid w-full grid-cols-2 bg-purple-800/50">
+              <TabsList className="grid w-full grid-cols-2 bg-purple-100">
                 <TabsTrigger value="options">Scan Options</TabsTrigger>
                 <TabsTrigger value="engines">Engine Config</TabsTrigger>
               </TabsList>
@@ -221,7 +221,7 @@ export function FileScanner({ onScanComplete, config, setIsScanning }: FileScann
                   <div className="flex items-center justify-between">
                     <div>
                       <Label className="text-white">Deep Analysis</Label>
-                      <p className="text-xs text-purple-400">Comprehensive file structure analysis</p>
+                      <p className="text-xs text-purple-600">Comprehensive file structure analysis</p>
                     </div>
                     <Switch
                       checked={scanOptions.deepScan}
@@ -232,7 +232,7 @@ export function FileScanner({ onScanComplete, config, setIsScanning }: FileScann
                   <div className="flex items-center justify-between">
                     <div>
                       <Label className="text-white">Generate Hashes</Label>
-                      <p className="text-xs text-purple-400">MD5, SHA1, SHA256, CRC32</p>
+                      <p className="text-xs text-purple-600">MD5, SHA1, SHA256, CRC32</p>
                     </div>
                     <Switch
                       checked={scanOptions.generateHashes}
@@ -243,7 +243,7 @@ export function FileScanner({ onScanComplete, config, setIsScanning }: FileScann
                   <div className="flex items-center justify-between">
                     <div>
                       <Label className="text-white">Extract Metadata</Label>
-                      <p className="text-xs text-purple-400">Author, creation date, properties</p>
+                      <p className="text-xs text-purple-600">Author, creation date, properties</p>
                     </div>
                     <Switch
                       checked={scanOptions.extractMetadata}
@@ -254,7 +254,7 @@ export function FileScanner({ onScanComplete, config, setIsScanning }: FileScann
                   <div className="flex items-center justify-between">
                     <div>
                       <Label className="text-white">Validate Signatures</Label>
-                      <p className="text-xs text-purple-400">Digital signature verification</p>
+                      <p className="text-xs text-purple-600">Digital signature verification</p>
                     </div>
                     <Switch
                       checked={scanOptions.validateSignatures}
@@ -271,7 +271,7 @@ export function FileScanner({ onScanComplete, config, setIsScanning }: FileScann
                   <Label className="text-white">Active Engines</Label>
                   <div className="grid grid-cols-2 gap-2">
                     {config.engines.map((engine: string) => (
-                      <Badge key={engine} variant="secondary" className="bg-purple-700 text-purple-100">
+                      <Badge key={engine} variant="secondary" className="bg-purple-500 text-purple-500">
                         {engine}
                       </Badge>
                     ))}
@@ -283,7 +283,7 @@ export function FileScanner({ onScanComplete, config, setIsScanning }: FileScann
                   <Input
                     type="number"
                     value={config.threadPool}
-                    className="bg-purple-800/50 border-purple-600 text-white"
+                    className="bg-purple-100 border-purple-300 text-white"
                     readOnly
                   />
                 </div>
@@ -293,7 +293,7 @@ export function FileScanner({ onScanComplete, config, setIsScanning }: FileScann
                   <Input
                     type="number"
                     value={config.timeout}
-                    className="bg-purple-800/50 border-purple-600 text-white"
+                    className="bg-purple-100 border-purple-300 text-white"
                     readOnly
                   />
                 </div>
@@ -305,7 +305,7 @@ export function FileScanner({ onScanComplete, config, setIsScanning }: FileScann
 
       {/* Detailed Results */}
       {scanDetails && scanStatus === "complete" && (
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardHeader>
             <CardTitle className="text-white flex items-center gap-2">
               <Microscope className="w-5 h-5" />
@@ -314,7 +314,7 @@ export function FileScanner({ onScanComplete, config, setIsScanning }: FileScann
           </CardHeader>
           <CardContent>
             <Tabs defaultValue="overview" className="space-y-4">
-              <TabsList className="grid w-full grid-cols-5 bg-purple-800/50">
+              <TabsList className="grid w-full grid-cols-5 bg-purple-100">
                 <TabsTrigger value="overview">Overview</TabsTrigger>
                 <TabsTrigger value="hashes">Hashes</TabsTrigger>
                 <TabsTrigger value="metadata">Metadata</TabsTrigger>
@@ -324,29 +324,29 @@ export function FileScanner({ onScanComplete, config, setIsScanning }: FileScann
 
               <TabsContent value="overview" className="space-y-4">
                 <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                  <div className="p-3 bg-purple-800/30 rounded-lg">
-                    <p className="text-xs text-purple-400">File Type</p>
+                  <div className="p-3 bg-purple-50 rounded-lg">
+                    <p className="text-xs text-purple-600">File Type</p>
                     <p className="text-white font-medium">{scanDetails.detected_type}</p>
                   </div>
-                  <div className="p-3 bg-purple-800/30 rounded-lg">
-                    <p className="text-xs text-purple-400">Confidence</p>
+                  <div className="p-3 bg-purple-50 rounded-lg">
+                    <p className="text-xs text-purple-600">Confidence</p>
                     <p className="text-white font-medium">{(scanDetails.confidence * 100).toFixed(1)}%</p>
                   </div>
-                  <div className="p-3 bg-purple-800/30 rounded-lg">
-                    <p className="text-xs text-purple-400">Scan Time</p>
+                  <div className="p-3 bg-purple-50 rounded-lg">
+                    <p className="text-xs text-purple-600">Scan Time</p>
                     <p className="text-white font-medium">{scanDetails.scan_time}</p>
                   </div>
-                  <div className="p-3 bg-purple-800/30 rounded-lg">
-                    <p className="text-xs text-purple-400">Probium Version</p>
+                  <div className="p-3 bg-purple-50 rounded-lg">
+                    <p className="text-xs text-purple-600">Probium Version</p>
                     <p className="text-white font-medium">{scanDetails.probium_version}</p>
                   </div>
                 </div>
 
                 <div className="space-y-2">
-                  <p className="text-sm font-medium text-purple-300">Engines Used:</p>
+                  <p className="text-sm font-medium text-purple-700">Engines Used:</p>
                   <div className="flex flex-wrap gap-2">
                     {scanDetails.engines_used.map((engine: string) => (
-                      <Badge key={engine} variant="secondary" className="bg-purple-700 text-purple-100">
+                      <Badge key={engine} variant="secondary" className="bg-purple-500 text-purple-500">
                         {engine}
                       </Badge>
                     ))}
@@ -358,8 +358,8 @@ export function FileScanner({ onScanComplete, config, setIsScanning }: FileScann
                 <div className="space-y-3">
                   {scanDetails.hashes &&
                     Object.entries(scanDetails.hashes).map(([type, hash]) => (
-                      <div key={type} className="flex items-center justify-between p-3 bg-purple-800/30 rounded-lg">
-                        <span className="text-purple-300 uppercase font-medium">{type}</span>
+                      <div key={type} className="flex items-center justify-between p-3 bg-purple-50 rounded-lg">
+                        <span className="text-purple-700 uppercase font-medium">{type}</span>
                         <code className="text-white text-sm font-mono">{hash}</code>
                       </div>
                     ))}
@@ -370,8 +370,8 @@ export function FileScanner({ onScanComplete, config, setIsScanning }: FileScann
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   {scanDetails.metadata &&
                     Object.entries(scanDetails.metadata).map(([key, value]) => (
-                      <div key={key} className="p-3 bg-purple-800/30 rounded-lg">
-                        <p className="text-xs text-purple-400 capitalize">{key.replace(/([A-Z])/g, " $1")}</p>
+                      <div key={key} className="p-3 bg-purple-50 rounded-lg">
+                        <p className="text-xs text-purple-600 capitalize">{key.replace(/([A-Z])/g, " $1")}</p>
                         <p className="text-white">{Array.isArray(value) ? value.join(", ") : String(value)}</p>
                       </div>
                     ))}
@@ -382,8 +382,8 @@ export function FileScanner({ onScanComplete, config, setIsScanning }: FileScann
                 <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
                   {scanDetails.structure &&
                     Object.entries(scanDetails.structure).map(([key, value]) => (
-                      <div key={key} className="p-3 bg-purple-800/30 rounded-lg">
-                        <p className="text-xs text-purple-400 capitalize">{key}</p>
+                      <div key={key} className="p-3 bg-purple-50 rounded-lg">
+                        <p className="text-xs text-purple-600 capitalize">{key}</p>
                         <p className="text-white font-medium">{String(value)}</p>
                       </div>
                     ))}
@@ -394,12 +394,12 @@ export function FileScanner({ onScanComplete, config, setIsScanning }: FileScann
                 <div className="space-y-4">
                   {scanDetails.security && (
                     <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                      <div className="p-4 bg-purple-800/30 rounded-lg">
-                        <p className="text-xs text-purple-400">Malware Score</p>
+                      <div className="p-4 bg-purple-50 rounded-lg">
+                        <p className="text-xs text-purple-600">Malware Score</p>
                         <p className="text-2xl font-bold text-white">{scanDetails.security.malware_score}</p>
                       </div>
-                      <div className="p-4 bg-purple-800/30 rounded-lg">
-                        <p className="text-xs text-purple-400">Threat Level</p>
+                      <div className="p-4 bg-purple-50 rounded-lg">
+                        <p className="text-xs text-purple-600">Threat Level</p>
                         <Badge
                           className={`mt-1 ${
                             scanDetails.security.threat_level === "low"
@@ -412,8 +412,8 @@ export function FileScanner({ onScanComplete, config, setIsScanning }: FileScann
                           {scanDetails.security.threat_level}
                         </Badge>
                       </div>
-                      <div className="p-4 bg-purple-800/30 rounded-lg">
-                        <p className="text-xs text-purple-400">Embedded Files</p>
+                      <div className="p-4 bg-purple-50 rounded-lg">
+                        <p className="text-xs text-purple-600">Embedded Files</p>
                         <p className="text-2xl font-bold text-white">{scanDetails.security.embedded.files}</p>
                       </div>
                     </div>

--- a/components/filetype-registry.tsx
+++ b/components/filetype-registry.tsx
@@ -95,7 +95,7 @@ export function FileTypeRegistry({ config, onConfigChange }: FileTypeRegistryPro
       image: "bg-green-700",
       archive: "bg-yellow-700",
       executable: "bg-red-700",
-      text: "bg-purple-700",
+      text: "bg-purple-500",
       video: "bg-pink-700",
       audio: "bg-cyan-700",
     }
@@ -104,19 +104,19 @@ export function FileTypeRegistry({ config, onConfigChange }: FileTypeRegistryPro
 
   return (
     <div className="space-y-6">
-      <Card className="bg-purple-900/30 border-purple-700">
+      <Card className="bg-purple-50 border-purple-300">
         <CardHeader>
           <CardTitle className="text-white flex items-center gap-2">
             <FileType className="w-5 h-5" />
             File Type Registry
           </CardTitle>
-          <CardDescription className="text-purple-300">
+          <CardDescription className="text-purple-700">
             Manage file type definitions, signatures, and detection rules
           </CardDescription>
         </CardHeader>
         <CardContent>
           <Tabs defaultValue="registry" className="space-y-4">
-            <TabsList className="grid w-full grid-cols-3 bg-purple-800/50">
+            <TabsList className="grid w-full grid-cols-3 bg-purple-100">
               <TabsTrigger value="registry">Registry</TabsTrigger>
               <TabsTrigger value="signatures">Signatures</TabsTrigger>
               <TabsTrigger value="custom">Custom Types</TabsTrigger>
@@ -126,12 +126,12 @@ export function FileTypeRegistry({ config, onConfigChange }: FileTypeRegistryPro
               {/* Search and Filter Controls */}
               <div className="flex flex-col md:flex-row gap-4">
                 <div className="relative flex-1">
-                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-purple-400 w-4 h-4" />
+                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-purple-600 w-4 h-4" />
                   <Input
                     placeholder="Search file types..."
                     value={searchTerm}
                     onChange={(e) => setSearchTerm(e.target.value)}
-                    className="pl-10 bg-purple-800/50 border-purple-600 text-white placeholder-purple-400"
+                    className="pl-10 bg-purple-100 border-purple-300 text-white placeholder-purple-400"
                   />
                 </div>
 
@@ -144,8 +144,8 @@ export function FileTypeRegistry({ config, onConfigChange }: FileTypeRegistryPro
                       onClick={() => setSelectedCategory(category)}
                       className={
                         selectedCategory === category
-                          ? "bg-purple-600 hover:bg-purple-700"
-                          : "border-purple-600 text-purple-300 bg-transparent hover:bg-purple-800/30"
+                          ? "bg-purple-400 hover:bg-purple-500"
+                          : "border-purple-300 text-purple-700 bg-transparent hover:bg-purple-50"
                       }
                     >
                       {category.charAt(0).toUpperCase() + category.slice(1)}
@@ -155,37 +155,37 @@ export function FileTypeRegistry({ config, onConfigChange }: FileTypeRegistryPro
               </div>
 
               {/* File Types Table */}
-              <Card className="bg-purple-800/30 border-purple-600">
+              <Card className="bg-purple-50 border-purple-300">
                 <CardContent className="p-0">
                   <Table>
                     <TableHeader>
-                      <TableRow className="border-purple-700">
-                        <TableHead className="text-purple-300">Type</TableHead>
-                        <TableHead className="text-purple-300">MIME Type</TableHead>
-                        <TableHead className="text-purple-300">Extensions</TableHead>
-                        <TableHead className="text-purple-300">Category</TableHead>
-                        <TableHead className="text-purple-300">Engines</TableHead>
-                        <TableHead className="text-purple-300">Actions</TableHead>
+                      <TableRow className="border-purple-300">
+                        <TableHead className="text-purple-700">Type</TableHead>
+                        <TableHead className="text-purple-700">MIME Type</TableHead>
+                        <TableHead className="text-purple-700">Extensions</TableHead>
+                        <TableHead className="text-purple-700">Category</TableHead>
+                        <TableHead className="text-purple-700">Engines</TableHead>
+                        <TableHead className="text-purple-700">Actions</TableHead>
                       </TableRow>
                     </TableHeader>
                     <TableBody>
                       {filteredFileTypes.map((fileType) => (
-                        <TableRow key={fileType.id} className="border-purple-700 hover:bg-purple-800/30">
+                        <TableRow key={fileType.id} className="border-purple-300 hover:bg-purple-50">
                           <TableCell>
                             <div>
                               <p className="font-medium text-white">{fileType.name}</p>
-                              <p className="text-sm text-purple-400">{fileType.description}</p>
+                              <p className="text-sm text-purple-600">{fileType.description}</p>
                             </div>
                           </TableCell>
                           <TableCell>
-                            <code className="text-purple-300 bg-purple-900/50 px-2 py-1 rounded text-xs">
+                            <code className="text-purple-700 bg-purple-50 px-2 py-1 rounded text-xs">
                               {fileType.mime_type}
                             </code>
                           </TableCell>
                           <TableCell>
                             <div className="flex flex-wrap gap-1">
                               {fileType.extensions.map((ext) => (
-                                <Badge key={ext} variant="outline" className="border-purple-600 text-purple-300">
+                                <Badge key={ext} variant="outline" className="border-purple-300 text-purple-700">
                                   .{ext}
                                 </Badge>
                               ))}
@@ -197,7 +197,7 @@ export function FileTypeRegistry({ config, onConfigChange }: FileTypeRegistryPro
                           <TableCell>
                             <div className="flex flex-wrap gap-1">
                               {fileType.engines.map((engine) => (
-                                <Badge key={engine} variant="secondary" className="bg-purple-700 text-purple-100">
+                                <Badge key={engine} variant="secondary" className="bg-purple-500 text-purple-500">
                                   {engine}
                                 </Badge>
                               ))}
@@ -205,7 +205,7 @@ export function FileTypeRegistry({ config, onConfigChange }: FileTypeRegistryPro
                           </TableCell>
                           <TableCell>
                             <div className="flex gap-1">
-                              <Button variant="ghost" size="sm" className="text-purple-300 hover:text-white">
+                              <Button variant="ghost" size="sm" className="text-purple-700 hover:text-white">
                                 <Edit className="w-4 h-4" />
                               </Button>
                               <Button variant="ghost" size="sm" className="text-red-400 hover:text-red-300">
@@ -222,34 +222,34 @@ export function FileTypeRegistry({ config, onConfigChange }: FileTypeRegistryPro
             </TabsContent>
 
             <TabsContent value="signatures" className="space-y-4">
-              <Card className="bg-purple-800/30 border-purple-600">
+              <Card className="bg-purple-50 border-purple-300">
                 <CardHeader>
                   <CardTitle className="text-white text-lg">Magic Byte Signatures</CardTitle>
-                  <CardDescription className="text-purple-300">
+                  <CardDescription className="text-purple-700">
                     Binary signatures used for file type detection
                   </CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-4">
                   {filteredFileTypes.map((fileType) => (
-                    <div key={fileType.id} className="p-4 bg-purple-900/30 rounded border border-purple-700">
+                    <div key={fileType.id} className="p-4 bg-purple-50 rounded border border-purple-300">
                       <div className="flex items-center justify-between mb-2">
                         <h3 className="text-white font-medium">{fileType.name}</h3>
                         <Badge className={getCategoryColor(fileType.category)}>{fileType.category}</Badge>
                       </div>
                       <div className="space-y-2">
                         <div>
-                          <Label className="text-purple-300 text-sm">Magic Bytes</Label>
-                          <code className="block text-purple-200 bg-purple-900/50 p-2 rounded font-mono text-sm">
+                          <Label className="text-purple-700 text-sm">Magic Bytes</Label>
+                          <code className="block text-purple-600 bg-purple-50 p-2 rounded font-mono text-sm">
                             {fileType.magic_bytes}
                           </code>
                         </div>
                         <div className="flex items-center gap-4">
                           <div>
-                            <Label className="text-purple-300 text-sm">Confidence Threshold</Label>
+                            <Label className="text-purple-700 text-sm">Confidence Threshold</Label>
                             <p className="text-white">{(fileType.confidence_threshold * 100).toFixed(0)}%</p>
                           </div>
                           <div>
-                            <Label className="text-purple-300 text-sm">Detection Engines</Label>
+                            <Label className="text-purple-700 text-sm">Detection Engines</Label>
                             <p className="text-white">{fileType.engines.join(", ")}</p>
                           </div>
                         </div>
@@ -261,53 +261,53 @@ export function FileTypeRegistry({ config, onConfigChange }: FileTypeRegistryPro
             </TabsContent>
 
             <TabsContent value="custom" className="space-y-4">
-              <Card className="bg-purple-800/30 border-purple-600">
+              <Card className="bg-purple-50 border-purple-300">
                 <CardHeader>
                   <CardTitle className="text-white text-lg">Custom File Types</CardTitle>
-                  <CardDescription className="text-purple-300">Define custom file type detection rules</CardDescription>
+                  <CardDescription className="text-purple-700">Define custom file type detection rules</CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-4">
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div className="space-y-2">
-                      <Label className="text-purple-300">Type Name</Label>
+                      <Label className="text-purple-700">Type Name</Label>
                       <Input
                         placeholder="Custom Document"
-                        className="bg-purple-900/50 border-purple-600 text-white placeholder-purple-400"
+                        className="bg-purple-50 border-purple-300 text-white placeholder-purple-400"
                       />
                     </div>
                     <div className="space-y-2">
-                      <Label className="text-purple-300">MIME Type</Label>
+                      <Label className="text-purple-700">MIME Type</Label>
                       <Input
                         placeholder="application/x-custom"
-                        className="bg-purple-900/50 border-purple-600 text-white placeholder-purple-400"
+                        className="bg-purple-50 border-purple-300 text-white placeholder-purple-400"
                       />
                     </div>
                     <div className="space-y-2">
-                      <Label className="text-purple-300">File Extensions</Label>
+                      <Label className="text-purple-700">File Extensions</Label>
                       <Input
                         placeholder="cust,custom"
-                        className="bg-purple-900/50 border-purple-600 text-white placeholder-purple-400"
+                        className="bg-purple-50 border-purple-300 text-white placeholder-purple-400"
                       />
                     </div>
                     <div className="space-y-2">
-                      <Label className="text-purple-300">Magic Bytes (Hex)</Label>
+                      <Label className="text-purple-700">Magic Bytes (Hex)</Label>
                       <Input
                         placeholder="\\x43\\x55\\x53\\x54"
-                        className="bg-purple-900/50 border-purple-600 text-white placeholder-purple-400"
+                        className="bg-purple-50 border-purple-300 text-white placeholder-purple-400"
                       />
                     </div>
                   </div>
 
                   <div className="flex gap-2">
-                    <Button className="bg-purple-600 hover:bg-purple-700">
+                    <Button className="bg-purple-400 hover:bg-purple-500">
                       <Plus className="w-4 h-4 mr-2" />
                       Add Custom Type
                     </Button>
-                    <Button variant="outline" className="border-purple-600 text-purple-300 bg-transparent">
+                    <Button variant="outline" className="border-purple-300 text-purple-700 bg-transparent">
                       <Upload className="w-4 h-4 mr-2" />
                       Import Definitions
                     </Button>
-                    <Button variant="outline" className="border-purple-600 text-purple-300 bg-transparent">
+                    <Button variant="outline" className="border-purple-300 text-purple-700 bg-transparent">
                       <Download className="w-4 h-4 mr-2" />
                       Export Registry
                     </Button>

--- a/components/performance-profiler.tsx
+++ b/components/performance-profiler.tsx
@@ -125,48 +125,48 @@ export function PerformanceProfiler({ results, systemStats }: PerformanceProfile
     <div className="space-y-6">
       {/* Performance Overview */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardContent className="p-4">
             <div className="flex items-center gap-3">
               <Clock className="w-8 h-8 text-blue-400" />
               <div>
-                <p className="text-sm text-purple-300">Avg Scan Time</p>
+                <p className="text-sm text-purple-700">Avg Scan Time</p>
                 <p className="text-2xl font-bold text-white">{performanceMetrics.avgScanTime.toFixed(2)}s</p>
               </div>
             </div>
           </CardContent>
         </Card>
 
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardContent className="p-4">
             <div className="flex items-center gap-3">
               <TrendingUp className="w-8 h-8 text-green-400" />
               <div>
-                <p className="text-sm text-purple-300">Throughput</p>
+                <p className="text-sm text-purple-700">Throughput</p>
                 <p className="text-2xl font-bold text-white">{performanceMetrics.throughput.toFixed(1)} f/s</p>
               </div>
             </div>
           </CardContent>
         </Card>
 
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardContent className="p-4">
             <div className="flex items-center gap-3">
-              <Gauge className="w-8 h-8 text-purple-400" />
+              <Gauge className="w-8 h-8 text-purple-600" />
               <div>
-                <p className="text-sm text-purple-300">Efficiency Score</p>
+                <p className="text-sm text-purple-700">Efficiency Score</p>
                 <p className="text-2xl font-bold text-white">{getEfficiencyScore()}%</p>
               </div>
             </div>
           </CardContent>
         </Card>
 
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardContent className="p-4">
             <div className="flex items-center gap-3">
               <AlertTriangle className="w-8 h-8 text-yellow-400" />
               <div>
-                <p className="text-sm text-purple-300">Bottlenecks</p>
+                <p className="text-sm text-purple-700">Bottlenecks</p>
                 <p className="text-2xl font-bold text-white">{performanceMetrics.bottlenecks.length}</p>
               </div>
             </div>
@@ -175,19 +175,19 @@ export function PerformanceProfiler({ results, systemStats }: PerformanceProfile
       </div>
 
       {/* Performance Analysis */}
-      <Card className="bg-purple-900/30 border-purple-700">
+      <Card className="bg-purple-50 border-purple-300">
         <CardHeader>
           <CardTitle className="text-white flex items-center gap-2">
             <Gauge className="w-5 h-5" />
             Performance Profiler
           </CardTitle>
-          <CardDescription className="text-purple-300">
+          <CardDescription className="text-purple-700">
             Detailed performance analysis and optimization recommendations
           </CardDescription>
         </CardHeader>
         <CardContent>
           <Tabs defaultValue="overview" className="space-y-4">
-            <TabsList className="grid w-full grid-cols-4 bg-purple-800/50">
+            <TabsList className="grid w-full grid-cols-4 bg-purple-100">
               <TabsTrigger value="overview">Overview</TabsTrigger>
               <TabsTrigger value="engines">Engine Performance</TabsTrigger>
               <TabsTrigger value="bottlenecks">Bottlenecks</TabsTrigger>
@@ -196,14 +196,14 @@ export function PerformanceProfiler({ results, systemStats }: PerformanceProfile
 
             <TabsContent value="overview" className="space-y-4">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <Card className="bg-purple-800/30 border-purple-600">
+                <Card className="bg-purple-50 border-purple-300">
                   <CardHeader>
                     <CardTitle className="text-white text-lg">Scan Performance</CardTitle>
                   </CardHeader>
                   <CardContent className="space-y-4">
                     <div className="space-y-3">
                       <div className="flex justify-between">
-                        <span className="text-purple-300">Average Time</span>
+                        <span className="text-purple-700">Average Time</span>
                         <span
                           className={`font-medium ${getPerformanceColor(performanceMetrics.avgScanTime, { good: 0.5, warning: 1.0 })}`}
                         >
@@ -211,22 +211,22 @@ export function PerformanceProfiler({ results, systemStats }: PerformanceProfile
                         </span>
                       </div>
                       <div className="flex justify-between">
-                        <span className="text-purple-300">Fastest Scan</span>
+                        <span className="text-purple-700">Fastest Scan</span>
                         <span className="text-green-400 font-medium">{performanceMetrics.fastestScan.toFixed(2)}s</span>
                       </div>
                       <div className="flex justify-between">
-                        <span className="text-purple-300">Slowest Scan</span>
+                        <span className="text-purple-700">Slowest Scan</span>
                         <span className="text-red-400 font-medium">{performanceMetrics.slowestScan.toFixed(2)}s</span>
                       </div>
                       <div className="flex justify-between">
-                        <span className="text-purple-300">Total Time</span>
+                        <span className="text-purple-700">Total Time</span>
                         <span className="text-white font-medium">{performanceMetrics.totalScanTime.toFixed(2)}s</span>
                       </div>
                     </div>
                   </CardContent>
                 </Card>
 
-                <Card className="bg-purple-800/30 border-purple-600">
+                <Card className="bg-purple-50 border-purple-300">
                   <CardHeader>
                     <CardTitle className="text-white text-lg">System Resources</CardTitle>
                   </CardHeader>
@@ -234,36 +234,36 @@ export function PerformanceProfiler({ results, systemStats }: PerformanceProfile
                     <div className="space-y-3">
                       <div>
                         <div className="flex justify-between mb-1">
-                          <span className="text-purple-300">CPU Usage</span>
+                          <span className="text-purple-700">CPU Usage</span>
                           <span
                             className={`font-medium ${getPerformanceColor(systemStats.cpu_usage, { good: 50, warning: 80 })}`}
                           >
                             {systemStats.cpu_usage.toFixed(1)}%
                           </span>
                         </div>
-                        <Progress value={systemStats.cpu_usage} className="bg-purple-900" />
+                        <Progress value={systemStats.cpu_usage} className="bg-purple-200" />
                       </div>
                       <div>
                         <div className="flex justify-between mb-1">
-                          <span className="text-purple-300">Memory Usage</span>
+                          <span className="text-purple-700">Memory Usage</span>
                           <span
                             className={`font-medium ${getPerformanceColor(systemStats.memory_usage, { good: 60, warning: 85 })}`}
                           >
                             {systemStats.memory_usage.toFixed(1)}%
                           </span>
                         </div>
-                        <Progress value={systemStats.memory_usage} className="bg-purple-900" />
+                        <Progress value={systemStats.memory_usage} className="bg-purple-200" />
                       </div>
                       <div>
                         <div className="flex justify-between mb-1">
-                          <span className="text-purple-300">Disk Usage</span>
+                          <span className="text-purple-700">Disk Usage</span>
                           <span
                             className={`font-medium ${getPerformanceColor(systemStats.disk_usage, { good: 70, warning: 90 })}`}
                           >
                             {systemStats.disk_usage.toFixed(1)}%
                           </span>
                         </div>
-                        <Progress value={systemStats.disk_usage} className="bg-purple-900" />
+                        <Progress value={systemStats.disk_usage} className="bg-purple-200" />
                       </div>
                     </div>
                   </CardContent>
@@ -272,7 +272,7 @@ export function PerformanceProfiler({ results, systemStats }: PerformanceProfile
             </TabsContent>
 
             <TabsContent value="engines" className="space-y-4">
-              <Card className="bg-purple-800/30 border-purple-600">
+              <Card className="bg-purple-50 border-purple-300">
                 <CardHeader>
                   <CardTitle className="text-white text-lg">Engine Performance Analysis</CardTitle>
                 </CardHeader>
@@ -281,19 +281,19 @@ export function PerformanceProfiler({ results, systemStats }: PerformanceProfile
                     {Object.entries(performanceMetrics.enginePerformance).map(([engine, perf]) => (
                       <div
                         key={engine}
-                        className="flex items-center justify-between p-3 bg-purple-900/30 rounded border border-purple-700"
+                        className="flex items-center justify-between p-3 bg-purple-50 rounded border border-purple-300"
                       >
                         <div className="flex items-center gap-3">
-                          <Cpu className="w-5 h-5 text-purple-400" />
+                          <Cpu className="w-5 h-5 text-purple-600" />
                           <div>
                             <p className="text-white font-medium capitalize">{engine}</p>
-                            <p className="text-purple-400 text-sm">{perf.count} scans</p>
+                            <p className="text-purple-600 text-sm">{perf.count} scans</p>
                           </div>
                         </div>
                         <div className="flex items-center gap-4">
                           <div className="text-right">
                             <p className="text-white text-sm">{perf.avgTime.toFixed(3)}s avg</p>
-                            <p className="text-purple-400 text-xs">{perf.efficiency.toFixed(1)} f/s</p>
+                            <p className="text-purple-600 text-xs">{perf.efficiency.toFixed(1)} f/s</p>
                           </div>
                           <Badge
                             className={
@@ -311,7 +311,7 @@ export function PerformanceProfiler({ results, systemStats }: PerformanceProfile
             </TabsContent>
 
             <TabsContent value="bottlenecks" className="space-y-4">
-              <Card className="bg-purple-800/30 border-purple-600">
+              <Card className="bg-purple-50 border-purple-300">
                 <CardHeader>
                   <CardTitle className="text-white text-lg">Performance Bottlenecks</CardTitle>
                 </CardHeader>
@@ -331,7 +331,7 @@ export function PerformanceProfiler({ results, systemStats }: PerformanceProfile
                       <div className="text-center py-8">
                         <CheckCircle className="w-12 h-12 text-green-400 mx-auto mb-4" />
                         <h3 className="text-lg font-semibold text-white mb-2">No Bottlenecks Detected</h3>
-                        <p className="text-purple-300">System is performing optimally</p>
+                        <p className="text-purple-700">System is performing optimally</p>
                       </div>
                     )}
                   </div>
@@ -340,7 +340,7 @@ export function PerformanceProfiler({ results, systemStats }: PerformanceProfile
             </TabsContent>
 
             <TabsContent value="optimization" className="space-y-4">
-              <Card className="bg-purple-800/30 border-purple-600">
+              <Card className="bg-purple-50 border-purple-300">
                 <CardHeader>
                   <CardTitle className="text-white text-lg">Optimization Recommendations</CardTitle>
                 </CardHeader>
@@ -360,24 +360,24 @@ export function PerformanceProfiler({ results, systemStats }: PerformanceProfile
                       <div className="text-center py-8">
                         <CheckCircle className="w-12 h-12 text-green-400 mx-auto mb-4" />
                         <h3 className="text-lg font-semibold text-white mb-2">System Optimized</h3>
-                        <p className="text-purple-300">No optimization recommendations at this time</p>
+                        <p className="text-purple-700">No optimization recommendations at this time</p>
                       </div>
                     )}
                   </div>
 
-                  <div className="mt-6 p-4 bg-purple-900/30 border border-purple-600 rounded">
+                  <div className="mt-6 p-4 bg-purple-50 border border-purple-300 rounded">
                     <h4 className="text-white font-medium mb-3">Quick Optimization Actions</h4>
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
-                      <button className="p-2 bg-purple-700 hover:bg-purple-600 rounded text-white text-sm transition-colors">
+                      <button className="p-2 bg-purple-500 hover:bg-purple-400 rounded text-white text-sm transition-colors">
                         Optimize Thread Pool
                       </button>
-                      <button className="p-2 bg-purple-700 hover:bg-purple-600 rounded text-white text-sm transition-colors">
+                      <button className="p-2 bg-purple-500 hover:bg-purple-400 rounded text-white text-sm transition-colors">
                         Clear Cache
                       </button>
-                      <button className="p-2 bg-purple-700 hover:bg-purple-600 rounded text-white text-sm transition-colors">
+                      <button className="p-2 bg-purple-500 hover:bg-purple-400 rounded text-white text-sm transition-colors">
                         Disable Slow Engines
                       </button>
-                      <button className="p-2 bg-purple-700 hover:bg-purple-600 rounded text-white text-sm transition-colors">
+                      <button className="p-2 bg-purple-500 hover:bg-purple-400 rounded text-white text-sm transition-colors">
                         Generate Report
                       </button>
                     </div>

--- a/components/realtime-monitor.tsx
+++ b/components/realtime-monitor.tsx
@@ -126,16 +126,16 @@ export function RealTimeMonitor({ systemStats, isScanning }: RealTimeMonitorProp
     <div className="space-y-6">
       {/* Real-time Status Overview */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardContent className="p-4">
             <div className="flex items-center gap-3">
               <Cpu className="w-8 h-8 text-blue-400" />
               <div>
-                <p className="text-sm text-purple-300">CPU Usage</p>
+                <p className="text-sm text-purple-700">CPU Usage</p>
                 <p className="text-2xl font-bold text-white">{systemStats.cpu_usage.toFixed(1)}%</p>
               </div>
             </div>
-            <div className="mt-2 w-full bg-purple-800/50 rounded-full h-2">
+            <div className="mt-2 w-full bg-purple-100 rounded-full h-2">
               <div
                 className="bg-blue-500 h-2 rounded-full transition-all duration-500"
                 style={{ width: `${systemStats.cpu_usage}%` }}
@@ -144,16 +144,16 @@ export function RealTimeMonitor({ systemStats, isScanning }: RealTimeMonitorProp
           </CardContent>
         </Card>
 
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardContent className="p-4">
             <div className="flex items-center gap-3">
               <MemoryStick className="w-8 h-8 text-green-400" />
               <div>
-                <p className="text-sm text-purple-300">Memory</p>
+                <p className="text-sm text-purple-700">Memory</p>
                 <p className="text-2xl font-bold text-white">{systemStats.memory_usage.toFixed(1)}%</p>
               </div>
             </div>
-            <div className="mt-2 w-full bg-purple-800/50 rounded-full h-2">
+            <div className="mt-2 w-full bg-purple-100 rounded-full h-2">
               <div
                 className="bg-green-500 h-2 rounded-full transition-all duration-500"
                 style={{ width: `${systemStats.memory_usage}%` }}
@@ -162,57 +162,57 @@ export function RealTimeMonitor({ systemStats, isScanning }: RealTimeMonitorProp
           </CardContent>
         </Card>
 
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardContent className="p-4">
             <div className="flex items-center gap-3">
-              <Activity className="w-8 h-8 text-purple-400" />
+              <Activity className="w-8 h-8 text-purple-600" />
               <div>
-                <p className="text-sm text-purple-300">Active Threads</p>
+                <p className="text-sm text-purple-700">Active Threads</p>
                 <p className="text-2xl font-bold text-white">{systemStats.active_threads}</p>
               </div>
             </div>
             <div className="mt-2 flex items-center gap-1">
               <div className="w-2 h-2 bg-purple-400 rounded-full animate-pulse" />
-              <span className="text-xs text-purple-400">{isScanning ? "Scanning" : "Idle"}</span>
+              <span className="text-xs text-purple-600">{isScanning ? "Scanning" : "Idle"}</span>
             </div>
           </CardContent>
         </Card>
 
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardContent className="p-4">
             <div className="flex items-center gap-3">
               <Network className="w-8 h-8 text-yellow-400" />
               <div>
-                <p className="text-sm text-purple-300">Connections</p>
+                <p className="text-sm text-purple-700">Connections</p>
                 <p className="text-2xl font-bold text-white">{Math.round(activeConnections)}</p>
               </div>
             </div>
-            <div className="mt-2 text-xs text-purple-400">API endpoints active</div>
+            <div className="mt-2 text-xs text-purple-600">API endpoints active</div>
           </CardContent>
         </Card>
       </div>
 
       {/* Real-time Monitoring Dashboard */}
-      <Card className="bg-purple-900/30 border-purple-700">
+      <Card className="bg-purple-50 border-purple-300">
         <CardHeader>
           <CardTitle className="text-white flex items-center gap-2">
             <Eye className="w-5 h-5" />
             Live System Monitor
           </CardTitle>
-          <CardDescription className="text-purple-300">
+          <CardDescription className="text-purple-700">
             Real-time system activity and performance monitoring
           </CardDescription>
         </CardHeader>
         <CardContent>
           <Tabs defaultValue="logs" className="space-y-4">
-            <TabsList className="grid w-full grid-cols-3 bg-purple-800/50">
+            <TabsList className="grid w-full grid-cols-3 bg-purple-100">
               <TabsTrigger value="logs">Activity Logs</TabsTrigger>
               <TabsTrigger value="performance">Performance</TabsTrigger>
               <TabsTrigger value="engines">Engine Status</TabsTrigger>
             </TabsList>
 
             <TabsContent value="logs" className="space-y-4">
-              <Card className="bg-purple-800/30 border-purple-600">
+              <Card className="bg-purple-50 border-purple-300">
                 <CardHeader>
                   <CardTitle className="text-white text-lg">Live Activity Feed</CardTitle>
                   <div className="flex items-center gap-2">
@@ -228,15 +228,15 @@ export function RealTimeMonitor({ systemStats, isScanning }: RealTimeMonitorProp
                         return (
                           <div
                             key={log.id}
-                            className="flex items-start gap-3 p-3 bg-purple-900/30 rounded border border-purple-700 hover:bg-purple-900/50 transition-colors"
+                            className="flex items-start gap-3 p-3 bg-purple-50 rounded border border-purple-300 hover:bg-purple-50 transition-colors"
                           >
                             <IconComponent className={`w-4 h-4 mt-0.5 ${getLevelColor(log.level)}`} />
                             <div className="flex-1 min-w-0">
                               <div className="flex items-center gap-2 mb-1">
-                                <Badge variant="outline" className="border-purple-600 text-purple-300 text-xs">
+                                <Badge variant="outline" className="border-purple-300 text-purple-700 text-xs">
                                   {log.component}
                                 </Badge>
-                                <span className="text-xs text-purple-400">
+                                <span className="text-xs text-purple-600">
                                   {new Date(log.timestamp).toLocaleTimeString()}
                                 </span>
                               </div>
@@ -253,17 +253,17 @@ export function RealTimeMonitor({ systemStats, isScanning }: RealTimeMonitorProp
 
             <TabsContent value="performance" className="space-y-4">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <Card className="bg-purple-800/30 border-purple-600">
+                <Card className="bg-purple-50 border-purple-300">
                   <CardHeader>
                     <CardTitle className="text-white text-lg">Resource Usage</CardTitle>
                   </CardHeader>
                   <CardContent className="space-y-4">
                     <div className="space-y-2">
                       <div className="flex justify-between">
-                        <span className="text-purple-300">CPU</span>
+                        <span className="text-purple-700">CPU</span>
                         <span className="text-white">{systemStats.cpu_usage.toFixed(1)}%</span>
                       </div>
-                      <div className="w-full bg-purple-900/50 rounded-full h-2">
+                      <div className="w-full bg-purple-50 rounded-full h-2">
                         <div
                           className="bg-blue-500 h-2 rounded-full transition-all duration-500"
                           style={{ width: `${systemStats.cpu_usage}%` }}
@@ -273,10 +273,10 @@ export function RealTimeMonitor({ systemStats, isScanning }: RealTimeMonitorProp
 
                     <div className="space-y-2">
                       <div className="flex justify-between">
-                        <span className="text-purple-300">Memory</span>
+                        <span className="text-purple-700">Memory</span>
                         <span className="text-white">{systemStats.memory_usage.toFixed(1)}%</span>
                       </div>
-                      <div className="w-full bg-purple-900/50 rounded-full h-2">
+                      <div className="w-full bg-purple-50 rounded-full h-2">
                         <div
                           className="bg-green-500 h-2 rounded-full transition-all duration-500"
                           style={{ width: `${systemStats.memory_usage}%` }}
@@ -286,10 +286,10 @@ export function RealTimeMonitor({ systemStats, isScanning }: RealTimeMonitorProp
 
                     <div className="space-y-2">
                       <div className="flex justify-between">
-                        <span className="text-purple-300">Disk</span>
+                        <span className="text-purple-700">Disk</span>
                         <span className="text-white">{systemStats.disk_usage.toFixed(1)}%</span>
                       </div>
-                      <div className="w-full bg-purple-900/50 rounded-full h-2">
+                      <div className="w-full bg-purple-50 rounded-full h-2">
                         <div
                           className="bg-yellow-500 h-2 rounded-full transition-all duration-500"
                           style={{ width: `${systemStats.disk_usage}%` }}
@@ -299,25 +299,25 @@ export function RealTimeMonitor({ systemStats, isScanning }: RealTimeMonitorProp
                   </CardContent>
                 </Card>
 
-                <Card className="bg-purple-800/30 border-purple-600">
+                <Card className="bg-purple-50 border-purple-300">
                   <CardHeader>
                     <CardTitle className="text-white text-lg">System Health</CardTitle>
                   </CardHeader>
                   <CardContent className="space-y-3">
                     <div className="flex items-center justify-between">
-                      <span className="text-purple-300">Overall Status</span>
+                      <span className="text-purple-700">Overall Status</span>
                       <Badge className="bg-green-700">Healthy</Badge>
                     </div>
                     <div className="flex items-center justify-between">
-                      <span className="text-purple-300">Uptime</span>
+                      <span className="text-purple-700">Uptime</span>
                       <span className="text-white">24h 15m</span>
                     </div>
                     <div className="flex items-center justify-between">
-                      <span className="text-purple-300">Total Scans</span>
+                      <span className="text-purple-700">Total Scans</span>
                       <span className="text-white">{systemStats.total_scans}</span>
                     </div>
                     <div className="flex items-center justify-between">
-                      <span className="text-purple-300">Active Engines</span>
+                      <span className="text-purple-700">Active Engines</span>
                       <span className="text-white">{Object.keys(systemStats.engine_stats).length}</span>
                     </div>
                   </CardContent>
@@ -326,7 +326,7 @@ export function RealTimeMonitor({ systemStats, isScanning }: RealTimeMonitorProp
             </TabsContent>
 
             <TabsContent value="engines" className="space-y-4">
-              <Card className="bg-purple-800/30 border-purple-600">
+              <Card className="bg-purple-50 border-purple-300">
                 <CardHeader>
                   <CardTitle className="text-white text-lg">Engine Status</CardTitle>
                 </CardHeader>
@@ -335,16 +335,16 @@ export function RealTimeMonitor({ systemStats, isScanning }: RealTimeMonitorProp
                     {Object.entries(systemStats.engine_stats).map(([engineName, stats]) => (
                       <div
                         key={engineName}
-                        className="flex items-center justify-between p-3 bg-purple-900/30 rounded border border-purple-700"
+                        className="flex items-center justify-between p-3 bg-purple-50 rounded border border-purple-300"
                       >
                         <div className="flex items-center gap-3">
                           <div className="w-2 h-2 bg-green-400 rounded-full" />
-                          <span className="text-purple-300 capitalize">{engineName}</span>
+                          <span className="text-purple-700 capitalize">{engineName}</span>
                         </div>
                         <div className="flex items-center gap-4">
                           <div className="text-right">
                             <p className="text-white text-sm">{stats.scans_completed} scans</p>
-                            <p className="text-purple-400 text-xs">
+                            <p className="text-purple-600 text-xs">
                               {stats.last_used ? new Date(stats.last_used).toLocaleTimeString() : "Never"}
                             </p>
                           </div>

--- a/components/scan-results.tsx
+++ b/components/scan-results.tsx
@@ -161,48 +161,48 @@ export function ScanResults({ results, onClear }: ScanResultsProps) {
     <div className="space-y-6">
       {/* Results Statistics */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardContent className="p-4">
             <div className="flex items-center gap-3">
-              <Database className="w-8 h-8 text-purple-400" />
+              <Database className="w-8 h-8 text-purple-600" />
               <div>
-                <p className="text-sm text-purple-300">Total Scans</p>
+                <p className="text-sm text-purple-700">Total Scans</p>
                 <p className="text-2xl font-bold text-white">{stats.total}</p>
               </div>
             </div>
           </CardContent>
         </Card>
 
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardContent className="p-4">
             <div className="flex items-center gap-3">
               <CheckCircle className="w-8 h-8 text-green-400" />
               <div>
-                <p className="text-sm text-purple-300">Avg Confidence</p>
+                <p className="text-sm text-purple-700">Avg Confidence</p>
                 <p className="text-2xl font-bold text-white">{(stats.avgConfidence * 100).toFixed(1)}%</p>
               </div>
             </div>
           </CardContent>
         </Card>
 
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardContent className="p-4">
             <div className="flex items-center gap-3">
               <Clock className="w-8 h-8 text-blue-400" />
               <div>
-                <p className="text-sm text-purple-300">Avg Scan Time</p>
+                <p className="text-sm text-purple-700">Avg Scan Time</p>
                 <p className="text-2xl font-bold text-white">{stats.avgScanTime.toFixed(2)}s</p>
               </div>
             </div>
           </CardContent>
         </Card>
 
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardContent className="p-4">
             <div className="flex items-center gap-3">
               <AlertTriangle className="w-8 h-8 text-red-400" />
               <div>
-                <p className="text-sm text-purple-300">Threats</p>
+                <p className="text-sm text-purple-700">Threats</p>
                 <p className="text-2xl font-bold text-white">{stats.threats}</p>
               </div>
             </div>
@@ -211,7 +211,7 @@ export function ScanResults({ results, onClear }: ScanResultsProps) {
       </div>
 
       {/* Results Management */}
-      <Card className="bg-purple-900/30 border-purple-700">
+      <Card className="bg-purple-50 border-purple-300">
         <CardHeader>
           <div className="flex items-center justify-between">
             <div>
@@ -219,17 +219,17 @@ export function ScanResults({ results, onClear }: ScanResultsProps) {
                 <BarChart3 className="w-5 h-5" />
                 Scan Results
               </CardTitle>
-              <CardDescription className="text-purple-300">
+              <CardDescription className="text-purple-700">
                 {filteredAndSortedResults.length} of {results.length} results
               </CardDescription>
             </div>
             <div className="flex gap-2">
               <Select onValueChange={(value) => exportResults(value)}>
-                <SelectTrigger className="w-32 bg-purple-800/50 border-purple-600 text-white">
+                <SelectTrigger className="w-32 bg-purple-100 border-purple-300 text-white">
                   <Download className="w-4 h-4 mr-2" />
                   <SelectValue placeholder="Export" />
                 </SelectTrigger>
-                <SelectContent className="bg-purple-800 border-purple-600">
+                <SelectContent className="bg-purple-200 border-purple-300">
                   <SelectItem value="json" className="text-white">
                     JSON
                   </SelectItem>
@@ -242,7 +242,7 @@ export function ScanResults({ results, onClear }: ScanResultsProps) {
                 onClick={onClear}
                 variant="outline"
                 size="sm"
-                className="border-purple-600 text-purple-300 bg-transparent"
+                className="border-purple-300 text-purple-700 bg-transparent"
               >
                 <Trash2 className="w-4 h-4 mr-2" />
                 Clear All
@@ -255,21 +255,21 @@ export function ScanResults({ results, onClear }: ScanResultsProps) {
             {/* Search and Filter Controls */}
             <div className="flex flex-col md:flex-row gap-4">
               <div className="relative flex-1">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-purple-400 w-4 h-4" />
+                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-purple-600 w-4 h-4" />
                 <Input
                   placeholder="Search by filename or file type..."
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
-                  className="pl-10 bg-purple-800/50 border-purple-600 text-white placeholder-purple-400"
+                  className="pl-10 bg-purple-100 border-purple-300 text-white placeholder-purple-400"
                 />
               </div>
 
               <Select value={filterType} onValueChange={setFilterType}>
-                <SelectTrigger className="w-48 bg-purple-800/50 border-purple-600 text-white">
+                <SelectTrigger className="w-48 bg-purple-100 border-purple-300 text-white">
                   <Filter className="w-4 h-4 mr-2" />
                   <SelectValue />
                 </SelectTrigger>
-                <SelectContent className="bg-purple-800 border-purple-600">
+                <SelectContent className="bg-purple-200 border-purple-300">
                   <SelectItem value="all" className="text-white">
                     All Results
                   </SelectItem>
@@ -286,10 +286,10 @@ export function ScanResults({ results, onClear }: ScanResultsProps) {
               </Select>
 
               <Select value={sortBy} onValueChange={setSortBy}>
-                <SelectTrigger className="w-40 bg-purple-800/50 border-purple-600 text-white">
+                <SelectTrigger className="w-40 bg-purple-100 border-purple-300 text-white">
                   <SelectValue />
                 </SelectTrigger>
-                <SelectContent className="bg-purple-800 border-purple-600">
+                <SelectContent className="bg-purple-200 border-purple-300">
                   <SelectItem value="timestamp" className="text-white">
                     Date
                   </SelectItem>
@@ -309,7 +309,7 @@ export function ScanResults({ results, onClear }: ScanResultsProps) {
                 variant="outline"
                 size="sm"
                 onClick={() => setSortOrder(sortOrder === "asc" ? "desc" : "asc")}
-                className="border-purple-600 text-purple-300"
+                className="border-purple-300 text-purple-700"
               >
                 {sortOrder === "asc" ? "↑" : "↓"}
               </Button>
@@ -317,33 +317,33 @@ export function ScanResults({ results, onClear }: ScanResultsProps) {
 
             {/* Results Table */}
             {filteredAndSortedResults.length > 0 ? (
-              <div className="rounded-lg border border-purple-700 overflow-hidden">
+              <div className="rounded-lg border border-purple-300 overflow-hidden">
                 <Table>
-                  <TableHeader className="bg-purple-800/50">
-                    <TableRow className="border-purple-700">
-                      <TableHead className="text-purple-300">File</TableHead>
-                      <TableHead className="text-purple-300">Type</TableHead>
-                      <TableHead className="text-purple-300">Confidence</TableHead>
-                      <TableHead className="text-purple-300">Size</TableHead>
-                      <TableHead className="text-purple-300">Threat Level</TableHead>
-                      <TableHead className="text-purple-300">Scan Time</TableHead>
-                      <TableHead className="text-purple-300">Actions</TableHead>
+                  <TableHeader className="bg-purple-100">
+                    <TableRow className="border-purple-300">
+                      <TableHead className="text-purple-700">File</TableHead>
+                      <TableHead className="text-purple-700">Type</TableHead>
+                      <TableHead className="text-purple-700">Confidence</TableHead>
+                      <TableHead className="text-purple-700">Size</TableHead>
+                      <TableHead className="text-purple-700">Threat Level</TableHead>
+                      <TableHead className="text-purple-700">Scan Time</TableHead>
+                      <TableHead className="text-purple-700">Actions</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
                     {filteredAndSortedResults.map((result) => (
-                      <TableRow key={result.id} className="border-purple-700 hover:bg-purple-800/30">
+                      <TableRow key={result.id} className="border-purple-300 hover:bg-purple-50">
                         <TableCell>
                           <div className="flex items-center gap-2">
-                            <FileText className="w-4 h-4 text-purple-400" />
+                            <FileText className="w-4 h-4 text-purple-600" />
                             <div>
                               <span className="font-medium text-white">{result.filename}</span>
-                              <p className="text-xs text-purple-400">{(result.size / 1024 / 1024).toFixed(2)} MB</p>
+                              <p className="text-xs text-purple-600">{(result.size / 1024 / 1024).toFixed(2)} MB</p>
                             </div>
                           </div>
                         </TableCell>
                         <TableCell>
-                          <Badge variant="outline" className="border-purple-600 text-purple-300">
+                          <Badge variant="outline" className="border-purple-300 text-purple-700">
                             {result.detectedType}
                           </Badge>
                         </TableCell>
@@ -352,13 +352,13 @@ export function ScanResults({ results, onClear }: ScanResultsProps) {
                             {(result.confidence * 100).toFixed(1)}%
                           </Badge>
                         </TableCell>
-                        <TableCell className="text-purple-300">{(result.size / 1024 / 1024).toFixed(2)} MB</TableCell>
+                        <TableCell className="text-purple-700">{(result.size / 1024 / 1024).toFixed(2)} MB</TableCell>
                         <TableCell>
                           <Badge className={getThreatColor(result.security?.threatLevel || "low")}>
                             {result.security?.threatLevel || "low"}
                           </Badge>
                         </TableCell>
-                        <TableCell className="text-purple-300">{result.performance?.scanTime || "N/A"}</TableCell>
+                        <TableCell className="text-purple-700">{result.performance?.scanTime || "N/A"}</TableCell>
                         <TableCell>
                           <Dialog>
                             <DialogTrigger asChild>
@@ -366,22 +366,22 @@ export function ScanResults({ results, onClear }: ScanResultsProps) {
                                 variant="ghost"
                                 size="sm"
                                 onClick={() => setSelectedResult(result)}
-                                className="text-purple-300 hover:text-white hover:bg-purple-700"
+                                className="text-purple-700 hover:text-white hover:bg-purple-500"
                               >
                                 <Eye className="w-4 h-4" />
                               </Button>
                             </DialogTrigger>
-                            <DialogContent className="max-w-4xl bg-purple-900 border-purple-700 text-white">
+                            <DialogContent className="max-w-4xl bg-purple-200 border-purple-300 text-white">
                               <DialogHeader>
                                 <DialogTitle className="text-white">Detailed Analysis: {result.filename}</DialogTitle>
-                                <DialogDescription className="text-purple-300">
+                                <DialogDescription className="text-purple-700">
                                   Comprehensive scan results from Probium analysis
                                 </DialogDescription>
                               </DialogHeader>
 
                               {selectedResult && (
                                 <Tabs defaultValue="overview" className="space-y-4">
-                                  <TabsList className="grid w-full grid-cols-6 bg-purple-800/50">
+                                  <TabsList className="grid w-full grid-cols-6 bg-purple-100">
                                     <TabsTrigger value="overview">Overview</TabsTrigger>
                                     <TabsTrigger value="hashes">Hashes</TabsTrigger>
                                     <TabsTrigger value="metadata">Metadata</TabsTrigger>
@@ -392,34 +392,34 @@ export function ScanResults({ results, onClear }: ScanResultsProps) {
 
                                   <TabsContent value="overview" className="space-y-4">
                                     <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                                      <div className="p-3 bg-purple-800/30 rounded-lg border border-purple-700">
-                                        <p className="text-xs text-purple-400">File Type</p>
+                                      <div className="p-3 bg-purple-50 rounded-lg border border-purple-300">
+                                        <p className="text-xs text-purple-600">File Type</p>
                                         <p className="text-white font-medium">{selectedResult.detectedType}</p>
                                       </div>
-                                      <div className="p-3 bg-purple-800/30 rounded-lg border border-purple-700">
-                                        <p className="text-xs text-purple-400">MIME Type</p>
+                                      <div className="p-3 bg-purple-50 rounded-lg border border-purple-300">
+                                        <p className="text-xs text-purple-600">MIME Type</p>
                                         <p className="text-white font-medium">{selectedResult.mimeType}</p>
                                       </div>
-                                      <div className="p-3 bg-purple-800/30 rounded-lg border border-purple-700">
-                                        <p className="text-xs text-purple-400">Confidence</p>
+                                      <div className="p-3 bg-purple-50 rounded-lg border border-purple-300">
+                                        <p className="text-xs text-purple-600">Confidence</p>
                                         <p className="text-white font-medium">
                                           {(selectedResult.confidence * 100).toFixed(1)}%
                                         </p>
                                       </div>
-                                      <div className="p-3 bg-purple-800/30 rounded-lg border border-purple-700">
-                                        <p className="text-xs text-purple-400">Probium Version</p>
+                                      <div className="p-3 bg-purple-50 rounded-lg border border-purple-300">
+                                        <p className="text-xs text-purple-600">Probium Version</p>
                                         <p className="text-white font-medium">{selectedResult.probiumVersion}</p>
                                       </div>
                                     </div>
 
                                     <div className="space-y-2">
-                                      <p className="text-sm font-medium text-purple-300">Detection Engines Used:</p>
+                                      <p className="text-sm font-medium text-purple-700">Detection Engines Used:</p>
                                       <div className="flex flex-wrap gap-2">
                                         {selectedResult.engines.map((engine: string) => (
                                           <Badge
                                             key={engine}
                                             variant="secondary"
-                                            className="bg-purple-700 text-purple-100"
+                                            className="bg-purple-500 text-purple-500"
                                           >
                                             {engine}
                                           </Badge>
@@ -432,13 +432,13 @@ export function ScanResults({ results, onClear }: ScanResultsProps) {
                                     {Object.entries(selectedResult.hashes || {}).map(([type, hash]) => (
                                       <div
                                         key={type}
-                                        className="flex items-center justify-between p-3 bg-purple-800/30 rounded-lg border border-purple-700"
+                                        className="flex items-center justify-between p-3 bg-purple-50 rounded-lg border border-purple-300"
                                       >
                                         <div className="flex items-center gap-2">
-                                          <Hash className="w-4 h-4 text-purple-400" />
-                                          <span className="text-purple-300 uppercase font-medium">{type}</span>
+                                          <Hash className="w-4 h-4 text-purple-600" />
+                                          <span className="text-purple-700 uppercase font-medium">{type}</span>
                                         </div>
-                                        <code className="text-white text-sm font-mono bg-purple-900/50 px-2 py-1 rounded">
+                                        <code className="text-white text-sm font-mono bg-purple-50 px-2 py-1 rounded">
                                           {hash as string}
                                         </code>
                                       </div>
@@ -450,9 +450,9 @@ export function ScanResults({ results, onClear }: ScanResultsProps) {
                                       {Object.entries(selectedResult.metadata || {}).map(([key, value]) => (
                                         <div
                                           key={key}
-                                          className="p-3 bg-purple-800/30 rounded-lg border border-purple-700"
+                                          className="p-3 bg-purple-50 rounded-lg border border-purple-300"
                                         >
-                                          <p className="text-xs text-purple-400 capitalize mb-1">
+                                          <p className="text-xs text-purple-600 capitalize mb-1">
                                             {key.replace(/([A-Z])/g, " $1")}
                                           </p>
                                           <p className="text-white">
@@ -468,9 +468,9 @@ export function ScanResults({ results, onClear }: ScanResultsProps) {
                                       {Object.entries(selectedResult.structure || {}).map(([key, value]) => (
                                         <div
                                           key={key}
-                                          className="p-3 bg-purple-800/30 rounded-lg border border-purple-700"
+                                          className="p-3 bg-purple-50 rounded-lg border border-purple-300"
                                         >
-                                          <p className="text-xs text-purple-400 capitalize mb-1">{key}</p>
+                                          <p className="text-xs text-purple-600 capitalize mb-1">{key}</p>
                                           <p className="text-white font-medium">{String(value)}</p>
                                         </div>
                                       ))}
@@ -479,19 +479,19 @@ export function ScanResults({ results, onClear }: ScanResultsProps) {
 
                                   <TabsContent value="security" className="space-y-4">
                                     <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                                      <div className="p-4 bg-purple-800/30 rounded-lg border border-purple-700">
+                                      <div className="p-4 bg-purple-50 rounded-lg border border-purple-300">
                                         <div className="flex items-center gap-2 mb-2">
-                                          <Shield className="w-5 h-5 text-purple-400" />
-                                          <p className="text-sm font-medium text-purple-300">Malware Score</p>
+                                          <Shield className="w-5 h-5 text-purple-600" />
+                                          <p className="text-sm font-medium text-purple-700">Malware Score</p>
                                         </div>
                                         <p className="text-2xl font-bold text-white">
                                           {selectedResult.security?.malwareScore || 0}
                                         </p>
                                       </div>
-                                      <div className="p-4 bg-purple-800/30 rounded-lg border border-purple-700">
+                                      <div className="p-4 bg-purple-50 rounded-lg border border-purple-300">
                                         <div className="flex items-center gap-2 mb-2">
-                                          <AlertTriangle className="w-5 h-5 text-purple-400" />
-                                          <p className="text-sm font-medium text-purple-300">Threat Level</p>
+                                          <AlertTriangle className="w-5 h-5 text-purple-600" />
+                                          <p className="text-sm font-medium text-purple-700">Threat Level</p>
                                         </div>
                                         <Badge
                                           className={getThreatColor(selectedResult.security?.threatLevel || "low")}
@@ -499,10 +499,10 @@ export function ScanResults({ results, onClear }: ScanResultsProps) {
                                           {selectedResult.security?.threatLevel || "low"}
                                         </Badge>
                                       </div>
-                                      <div className="p-4 bg-purple-800/30 rounded-lg border border-purple-700">
+                                      <div className="p-4 bg-purple-50 rounded-lg border border-purple-300">
                                         <div className="flex items-center gap-2 mb-2">
-                                          <FileText className="w-5 h-5 text-purple-400" />
-                                          <p className="text-sm font-medium text-purple-300">Embedded Files</p>
+                                          <FileText className="w-5 h-5 text-purple-600" />
+                                          <p className="text-sm font-medium text-purple-700">Embedded Files</p>
                                         </div>
                                         <p className="text-2xl font-bold text-white">
                                           {selectedResult.security?.embedded?.files || 0}
@@ -513,33 +513,33 @@ export function ScanResults({ results, onClear }: ScanResultsProps) {
 
                                   <TabsContent value="performance" className="space-y-4">
                                     <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                                      <div className="p-3 bg-purple-800/30 rounded-lg border border-purple-700">
+                                      <div className="p-3 bg-purple-50 rounded-lg border border-purple-300">
                                         <div className="flex items-center gap-2 mb-1">
-                                          <Clock className="w-4 h-4 text-purple-400" />
-                                          <p className="text-xs text-purple-400">Total Time</p>
+                                          <Clock className="w-4 h-4 text-purple-600" />
+                                          <p className="text-xs text-purple-600">Total Time</p>
                                         </div>
                                         <p className="text-white font-medium">{selectedResult.performance?.scanTime}</p>
                                       </div>
-                                      <div className="p-3 bg-purple-800/30 rounded-lg border border-purple-700">
+                                      <div className="p-3 bg-purple-50 rounded-lg border border-purple-300">
                                         <div className="flex items-center gap-2 mb-1">
-                                          <Activity className="w-4 h-4 text-purple-400" />
-                                          <p className="text-xs text-purple-400">Memory Used</p>
+                                          <Activity className="w-4 h-4 text-purple-600" />
+                                          <p className="text-xs text-purple-600">Memory Used</p>
                                         </div>
                                         <p className="text-white font-medium">
                                           {selectedResult.performance?.memoryUsed}
                                         </p>
                                       </div>
-                                      <div className="p-3 bg-purple-800/30 rounded-lg border border-purple-700">
+                                      <div className="p-3 bg-purple-50 rounded-lg border border-purple-300">
                                         <div className="flex items-center gap-2 mb-1">
-                                          <Cpu className="w-4 h-4 text-purple-400" />
-                                          <p className="text-xs text-purple-400">CPU Time</p>
+                                          <Cpu className="w-4 h-4 text-purple-600" />
+                                          <p className="text-xs text-purple-600">CPU Time</p>
                                         </div>
                                         <p className="text-white font-medium">{selectedResult.performance?.cpuTime}</p>
                                       </div>
-                                      <div className="p-3 bg-purple-800/30 rounded-lg border border-purple-700">
+                                      <div className="p-3 bg-purple-50 rounded-lg border border-purple-300">
                                         <div className="flex items-center gap-2 mb-1">
-                                          <TrendingUp className="w-4 h-4 text-purple-400" />
-                                          <p className="text-xs text-purple-400">Efficiency</p>
+                                          <TrendingUp className="w-4 h-4 text-purple-600" />
+                                          <p className="text-xs text-purple-600">Efficiency</p>
                                         </div>
                                         <p className="text-white font-medium">
                                           {(
@@ -554,14 +554,14 @@ export function ScanResults({ results, onClear }: ScanResultsProps) {
                                     </div>
 
                                     <div className="space-y-3">
-                                      <p className="text-sm font-medium text-purple-300">Engine Performance:</p>
+                                      <p className="text-sm font-medium text-purple-700">Engine Performance:</p>
                                       {Object.entries(selectedResult.performance?.engineTimes || {}).map(
                                         ([engine, time]) => (
                                           <div
                                             key={engine}
-                                            className="flex items-center justify-between p-2 bg-purple-800/30 rounded border border-purple-700"
+                                            className="flex items-center justify-between p-2 bg-purple-50 rounded border border-purple-300"
                                           >
-                                            <span className="text-purple-300 capitalize">{engine} Engine</span>
+                                            <span className="text-purple-700 capitalize">{engine} Engine</span>
                                             <span className="text-white font-mono">{time as string}</span>
                                           </div>
                                         ),
@@ -579,11 +579,11 @@ export function ScanResults({ results, onClear }: ScanResultsProps) {
                 </Table>
               </div>
             ) : (
-              <Card className="bg-purple-800/30 border-purple-700">
+              <Card className="bg-purple-50 border-purple-300">
                 <CardContent className="p-12 text-center">
-                  <FileText className="w-12 h-12 text-purple-400 mx-auto mb-4" />
+                  <FileText className="w-12 h-12 text-purple-600 mx-auto mb-4" />
                   <h3 className="text-lg font-semibold text-white mb-2">No Results Found</h3>
-                  <p className="text-purple-300">
+                  <p className="text-purple-700">
                     {results.length === 0
                       ? "Upload and scan files to see results here"
                       : "No results match your current filters"}
@@ -597,7 +597,7 @@ export function ScanResults({ results, onClear }: ScanResultsProps) {
 
       {/* File Type Distribution */}
       {Object.keys(stats.fileTypes).length > 0 && (
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardHeader>
             <CardTitle className="text-white flex items-center gap-2">
               <BarChart3 className="w-5 h-5" />
@@ -608,9 +608,9 @@ export function ScanResults({ results, onClear }: ScanResultsProps) {
             <div className="space-y-3">
               {Object.entries(stats.fileTypes).map(([type, count]) => (
                 <div key={type} className="flex items-center justify-between">
-                  <span className="text-purple-300">{type}</span>
+                  <span className="text-purple-700">{type}</span>
                   <div className="flex items-center gap-3">
-                    <div className="w-32 bg-purple-800/50 rounded-full h-2">
+                    <div className="w-32 bg-purple-100 rounded-full h-2">
                       <div
                         className="bg-purple-500 h-2 rounded-full"
                         style={{ width: `${(count / stats.total) * 100}%` }}

--- a/components/system-monitor.tsx
+++ b/components/system-monitor.tsx
@@ -70,27 +70,27 @@ export function SystemMonitor({ systemStats, config }: SystemMonitorProps) {
     <div className="space-y-6">
       {/* System Overview */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardContent className="p-4">
             <div className="flex items-center gap-3">
               <Cpu className={`w-8 h-8 ${getStatusColor(realTimeStats.cpu.usage, { warning: 70, critical: 90 })}`} />
               <div>
-                <p className="text-sm text-purple-300">CPU Usage</p>
+                <p className="text-sm text-purple-700">CPU Usage</p>
                 <p className="text-2xl font-bold text-white">{realTimeStats.cpu.usage.toFixed(1)}%</p>
               </div>
             </div>
-            <Progress value={realTimeStats.cpu.usage} className="mt-2 bg-purple-800" />
+            <Progress value={realTimeStats.cpu.usage} className="mt-2 bg-purple-200" />
           </CardContent>
         </Card>
 
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardContent className="p-4">
             <div className="flex items-center gap-3">
               <MemoryStick
                 className={`w-8 h-8 ${getStatusColor((realTimeStats.memory.used / realTimeStats.memory.total) * 100, { warning: 70, critical: 90 })}`}
               />
               <div>
-                <p className="text-sm text-purple-300">Memory</p>
+                <p className="text-sm text-purple-700">Memory</p>
                 <p className="text-2xl font-bold text-white">
                   {((realTimeStats.memory.used / realTimeStats.memory.total) * 100).toFixed(1)}%
                 </p>
@@ -98,19 +98,19 @@ export function SystemMonitor({ systemStats, config }: SystemMonitorProps) {
             </div>
             <Progress
               value={(realTimeStats.memory.used / realTimeStats.memory.total) * 100}
-              className="mt-2 bg-purple-800"
+              className="mt-2 bg-purple-200"
             />
           </CardContent>
         </Card>
 
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardContent className="p-4">
             <div className="flex items-center gap-3">
               <HardDrive
                 className={`w-8 h-8 ${getStatusColor((realTimeStats.disk.used / realTimeStats.disk.total) * 100, { warning: 80, critical: 95 })}`}
               />
               <div>
-                <p className="text-sm text-purple-300">Disk Usage</p>
+                <p className="text-sm text-purple-700">Disk Usage</p>
                 <p className="text-2xl font-bold text-white">
                   {((realTimeStats.disk.used / realTimeStats.disk.total) * 100).toFixed(1)}%
                 </p>
@@ -118,39 +118,39 @@ export function SystemMonitor({ systemStats, config }: SystemMonitorProps) {
             </div>
             <Progress
               value={(realTimeStats.disk.used / realTimeStats.disk.total) * 100}
-              className="mt-2 bg-purple-800"
+              className="mt-2 bg-purple-200"
             />
           </CardContent>
         </Card>
 
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardContent className="p-4">
             <div className="flex items-center gap-3">
               <Activity className="w-8 h-8 text-blue-400" />
               <div>
-                <p className="text-sm text-purple-300">Active Threads</p>
+                <p className="text-sm text-purple-700">Active Threads</p>
                 <p className="text-2xl font-bold text-white">{realTimeStats.processes.threads}</p>
               </div>
             </div>
-            <div className="mt-2 text-xs text-purple-400">Max: {config.threadPool}</div>
+            <div className="mt-2 text-xs text-purple-600">Max: {config.threadPool}</div>
           </CardContent>
         </Card>
       </div>
 
       {/* Detailed Monitoring */}
-      <Card className="bg-purple-900/30 border-purple-700">
+      <Card className="bg-purple-50 border-purple-300">
         <CardHeader>
           <CardTitle className="text-white flex items-center gap-2">
             <Server className="w-5 h-5" />
             System Monitoring
           </CardTitle>
-          <CardDescription className="text-purple-300">
+          <CardDescription className="text-purple-700">
             Real-time system performance and resource utilization
           </CardDescription>
         </CardHeader>
         <CardContent>
           <Tabs defaultValue="performance" className="space-y-4">
-            <TabsList className="grid w-full grid-cols-4 bg-purple-800/50">
+            <TabsList className="grid w-full grid-cols-4 bg-purple-100">
               <TabsTrigger value="performance">Performance</TabsTrigger>
               <TabsTrigger value="processes">Processes</TabsTrigger>
               <TabsTrigger value="network">Network</TabsTrigger>
@@ -159,7 +159,7 @@ export function SystemMonitor({ systemStats, config }: SystemMonitorProps) {
 
             <TabsContent value="performance" className="space-y-4">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <Card className="bg-purple-800/30 border-purple-600">
+                <Card className="bg-purple-50 border-purple-300">
                   <CardHeader>
                     <CardTitle className="text-white text-lg flex items-center gap-2">
                       <Cpu className="w-5 h-5" />
@@ -169,26 +169,26 @@ export function SystemMonitor({ systemStats, config }: SystemMonitorProps) {
                   <CardContent className="space-y-4">
                     <div className="space-y-3">
                       <div className="flex justify-between">
-                        <span className="text-purple-300">Usage</span>
+                        <span className="text-purple-700">Usage</span>
                         <span className="text-white">{realTimeStats.cpu.usage.toFixed(1)}%</span>
                       </div>
-                      <Progress value={realTimeStats.cpu.usage} className="bg-purple-900" />
+                      <Progress value={realTimeStats.cpu.usage} className="bg-purple-200" />
                     </div>
 
                     <div className="grid grid-cols-2 gap-4 pt-2">
-                      <div className="text-center p-2 bg-purple-900/50 rounded">
-                        <p className="text-xs text-purple-400">Cores</p>
+                      <div className="text-center p-2 bg-purple-50 rounded">
+                        <p className="text-xs text-purple-600">Cores</p>
                         <p className="text-lg font-bold text-white">{realTimeStats.cpu.cores}</p>
                       </div>
-                      <div className="text-center p-2 bg-purple-900/50 rounded">
-                        <p className="text-xs text-purple-400">Temperature</p>
+                      <div className="text-center p-2 bg-purple-50 rounded">
+                        <p className="text-xs text-purple-600">Temperature</p>
                         <p className="text-lg font-bold text-white">{realTimeStats.cpu.temperature.toFixed(0)}°C</p>
                       </div>
                     </div>
                   </CardContent>
                 </Card>
 
-                <Card className="bg-purple-800/30 border-purple-600">
+                <Card className="bg-purple-50 border-purple-300">
                   <CardHeader>
                     <CardTitle className="text-white text-lg flex items-center gap-2">
                       <MemoryStick className="w-5 h-5" />
@@ -198,7 +198,7 @@ export function SystemMonitor({ systemStats, config }: SystemMonitorProps) {
                   <CardContent className="space-y-4">
                     <div className="space-y-3">
                       <div className="flex justify-between">
-                        <span className="text-purple-300">Used</span>
+                        <span className="text-purple-700">Used</span>
                         <span className="text-white">
                           {(realTimeStats.memory.used / 1024).toFixed(1)} /{" "}
                           {(realTimeStats.memory.total / 1024).toFixed(1)} GB
@@ -206,19 +206,19 @@ export function SystemMonitor({ systemStats, config }: SystemMonitorProps) {
                       </div>
                       <Progress
                         value={(realTimeStats.memory.used / realTimeStats.memory.total) * 100}
-                        className="bg-purple-900"
+                        className="bg-purple-200"
                       />
                     </div>
 
                     <div className="grid grid-cols-2 gap-4 pt-2">
-                      <div className="text-center p-2 bg-purple-900/50 rounded">
-                        <p className="text-xs text-purple-400">Available</p>
+                      <div className="text-center p-2 bg-purple-50 rounded">
+                        <p className="text-xs text-purple-600">Available</p>
                         <p className="text-lg font-bold text-white">
                           {(realTimeStats.memory.available / 1024).toFixed(1)} GB
                         </p>
                       </div>
-                      <div className="text-center p-2 bg-purple-900/50 rounded">
-                        <p className="text-xs text-purple-400">Usage %</p>
+                      <div className="text-center p-2 bg-purple-50 rounded">
+                        <p className="text-xs text-purple-600">Usage %</p>
                         <p className="text-lg font-bold text-white">
                           {((realTimeStats.memory.used / realTimeStats.memory.total) * 100).toFixed(1)}%
                         </p>
@@ -228,7 +228,7 @@ export function SystemMonitor({ systemStats, config }: SystemMonitorProps) {
                 </Card>
               </div>
 
-              <Card className="bg-purple-800/30 border-purple-600">
+              <Card className="bg-purple-50 border-purple-300">
                 <CardHeader>
                   <CardTitle className="text-white text-lg flex items-center gap-2">
                     <HardDrive className="w-5 h-5" />
@@ -237,24 +237,24 @@ export function SystemMonitor({ systemStats, config }: SystemMonitorProps) {
                 </CardHeader>
                 <CardContent>
                   <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-                    <div className="text-center p-3 bg-purple-900/50 rounded">
-                      <p className="text-xs text-purple-400">Disk Usage</p>
+                    <div className="text-center p-3 bg-purple-50 rounded">
+                      <p className="text-xs text-purple-600">Disk Usage</p>
                       <p className="text-xl font-bold text-white">
                         {((realTimeStats.disk.used / realTimeStats.disk.total) * 100).toFixed(1)}%
                       </p>
                     </div>
-                    <div className="text-center p-3 bg-purple-900/50 rounded">
-                      <p className="text-xs text-purple-400">Free Space</p>
+                    <div className="text-center p-3 bg-purple-50 rounded">
+                      <p className="text-xs text-purple-600">Free Space</p>
                       <p className="text-xl font-bold text-white">
                         {(realTimeStats.disk.total - realTimeStats.disk.used).toFixed(0)} GB
                       </p>
                     </div>
-                    <div className="text-center p-3 bg-purple-900/50 rounded">
-                      <p className="text-xs text-purple-400">Read Speed</p>
+                    <div className="text-center p-3 bg-purple-50 rounded">
+                      <p className="text-xs text-purple-600">Read Speed</p>
                       <p className="text-xl font-bold text-white">{realTimeStats.disk.read.toFixed(1)} MB/s</p>
                     </div>
-                    <div className="text-center p-3 bg-purple-900/50 rounded">
-                      <p className="text-xs text-purple-400">Write Speed</p>
+                    <div className="text-center p-3 bg-purple-50 rounded">
+                      <p className="text-xs text-purple-600">Write Speed</p>
                       <p className="text-xl font-bold text-white">{realTimeStats.disk.write.toFixed(1)} MB/s</p>
                     </div>
                   </div>
@@ -264,41 +264,41 @@ export function SystemMonitor({ systemStats, config }: SystemMonitorProps) {
 
             <TabsContent value="processes" className="space-y-4">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <Card className="bg-purple-800/30 border-purple-600">
+                <Card className="bg-purple-50 border-purple-300">
                   <CardHeader>
                     <CardTitle className="text-white text-lg">Probium Processes</CardTitle>
                   </CardHeader>
                   <CardContent className="space-y-3">
-                    <div className="flex justify-between items-center p-2 bg-purple-900/50 rounded">
-                      <span className="text-purple-300">Main Process</span>
+                    <div className="flex justify-between items-center p-2 bg-purple-50 rounded">
+                      <span className="text-purple-700">Main Process</span>
                       <Badge className="bg-green-700">Running</Badge>
                     </div>
-                    <div className="flex justify-between items-center p-2 bg-purple-900/50 rounded">
-                      <span className="text-purple-300">Worker Threads</span>
+                    <div className="flex justify-between items-center p-2 bg-purple-50 rounded">
+                      <span className="text-purple-700">Worker Threads</span>
                       <Badge className="bg-blue-700">{realTimeStats.processes.threads}</Badge>
                     </div>
-                    <div className="flex justify-between items-center p-2 bg-purple-900/50 rounded">
-                      <span className="text-purple-300">Engine Processes</span>
-                      <Badge className="bg-purple-700">{config.engines.length}</Badge>
+                    <div className="flex justify-between items-center p-2 bg-purple-50 rounded">
+                      <span className="text-purple-700">Engine Processes</span>
+                      <Badge className="bg-purple-500">{config.engines.length}</Badge>
                     </div>
                   </CardContent>
                 </Card>
 
-                <Card className="bg-purple-800/30 border-purple-600">
+                <Card className="bg-purple-50 border-purple-300">
                   <CardHeader>
                     <CardTitle className="text-white text-lg">System Processes</CardTitle>
                   </CardHeader>
                   <CardContent className="space-y-3">
                     <div className="flex justify-between items-center">
-                      <span className="text-purple-300">Total Processes</span>
+                      <span className="text-purple-700">Total Processes</span>
                       <span className="text-white font-bold">{realTimeStats.processes.total}</span>
                     </div>
                     <div className="flex justify-between items-center">
-                      <span className="text-purple-300">Probium Processes</span>
+                      <span className="text-purple-700">Probium Processes</span>
                       <span className="text-white font-bold">{realTimeStats.processes.probium}</span>
                     </div>
                     <div className="flex justify-between items-center">
-                      <span className="text-purple-300">Thread Pool Size</span>
+                      <span className="text-purple-700">Thread Pool Size</span>
                       <span className="text-white font-bold">{config.threadPool}</span>
                     </div>
                   </CardContent>
@@ -307,7 +307,7 @@ export function SystemMonitor({ systemStats, config }: SystemMonitorProps) {
             </TabsContent>
 
             <TabsContent value="network" className="space-y-4">
-              <Card className="bg-purple-800/30 border-purple-600">
+              <Card className="bg-purple-50 border-purple-300">
                 <CardHeader>
                   <CardTitle className="text-white text-lg flex items-center gap-2">
                     <Network className="w-5 h-5" />
@@ -316,16 +316,16 @@ export function SystemMonitor({ systemStats, config }: SystemMonitorProps) {
                 </CardHeader>
                 <CardContent>
                   <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                    <div className="text-center p-4 bg-purple-900/50 rounded">
-                      <p className="text-sm text-purple-400">Incoming</p>
+                    <div className="text-center p-4 bg-purple-50 rounded">
+                      <p className="text-sm text-purple-600">Incoming</p>
                       <p className="text-2xl font-bold text-white">{realTimeStats.network.in.toFixed(1)} KB/s</p>
                     </div>
-                    <div className="text-center p-4 bg-purple-900/50 rounded">
-                      <p className="text-sm text-purple-400">Outgoing</p>
+                    <div className="text-center p-4 bg-purple-50 rounded">
+                      <p className="text-sm text-purple-600">Outgoing</p>
                       <p className="text-2xl font-bold text-white">{realTimeStats.network.out.toFixed(1)} KB/s</p>
                     </div>
-                    <div className="text-center p-4 bg-purple-900/50 rounded">
-                      <p className="text-sm text-purple-400">Connections</p>
+                    <div className="text-center p-4 bg-purple-50 rounded">
+                      <p className="text-sm text-purple-600">Connections</p>
                       <p className="text-2xl font-bold text-white">{realTimeStats.network.connections}</p>
                     </div>
                   </div>

--- a/components/threat-detection.tsx
+++ b/components/threat-detection.tsx
@@ -62,48 +62,48 @@ export function ThreatDetection({ results, config }: ThreatDetectionProps) {
     <div className="space-y-6">
       {/* Threat Overview */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardContent className="p-4">
             <div className="flex items-center gap-3">
               <AlertTriangle className="w-8 h-8 text-red-400" />
               <div>
-                <p className="text-sm text-purple-300">Total Threats</p>
+                <p className="text-sm text-purple-700">Total Threats</p>
                 <p className="text-2xl font-bold text-white">{threatAnalysis.totalThreats}</p>
               </div>
             </div>
           </CardContent>
         </Card>
 
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardContent className="p-4">
             <div className="flex items-center gap-3">
               <Shield className="w-8 h-8 text-yellow-400" />
               <div>
-                <p className="text-sm text-purple-300">High Risk</p>
+                <p className="text-sm text-purple-700">High Risk</p>
                 <p className="text-2xl font-bold text-white">{threatAnalysis.highThreats}</p>
               </div>
             </div>
           </CardContent>
         </Card>
 
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardContent className="p-4">
             <div className="flex items-center gap-3">
               <Eye className="w-8 h-8 text-orange-400" />
               <div>
-                <p className="text-sm text-purple-300">Anomalies</p>
+                <p className="text-sm text-purple-700">Anomalies</p>
                 <p className="text-2xl font-bold text-white">{threatAnalysis.anomalies.length}</p>
               </div>
             </div>
           </CardContent>
         </Card>
 
-        <Card className="bg-purple-900/30 border-purple-700">
+        <Card className="bg-purple-50 border-purple-300">
           <CardContent className="p-4">
             <div className="flex items-center gap-3">
-              <FileX className="w-8 h-8 text-purple-400" />
+              <FileX className="w-8 h-8 text-purple-600" />
               <div>
-                <p className="text-sm text-purple-300">Suspicious</p>
+                <p className="text-sm text-purple-700">Suspicious</p>
                 <p className="text-2xl font-bold text-white">{threatAnalysis.suspiciousFiles.length}</p>
               </div>
             </div>
@@ -112,17 +112,17 @@ export function ThreatDetection({ results, config }: ThreatDetectionProps) {
       </div>
 
       {/* Threat Analysis Dashboard */}
-      <Card className="bg-purple-900/30 border-purple-700">
+      <Card className="bg-purple-50 border-purple-300">
         <CardHeader>
           <CardTitle className="text-white flex items-center gap-2">
             <Shield className="w-5 h-5" />
             Threat Detection & Analysis
           </CardTitle>
-          <CardDescription className="text-purple-300">Security assessment and threat categorization</CardDescription>
+          <CardDescription className="text-purple-700">Security assessment and threat categorization</CardDescription>
         </CardHeader>
         <CardContent>
           <Tabs defaultValue="overview" className="space-y-4">
-            <TabsList className="grid w-full grid-cols-4 bg-purple-800/50">
+            <TabsList className="grid w-full grid-cols-4 bg-purple-100">
               <TabsTrigger value="overview">Overview</TabsTrigger>
               <TabsTrigger value="threats">Threats</TabsTrigger>
               <TabsTrigger value="anomalies">Anomalies</TabsTrigger>
@@ -131,16 +131,16 @@ export function ThreatDetection({ results, config }: ThreatDetectionProps) {
 
             <TabsContent value="overview" className="space-y-4">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <Card className="bg-purple-800/30 border-purple-600">
+                <Card className="bg-purple-50 border-purple-300">
                   <CardHeader>
                     <CardTitle className="text-white text-lg">Threat Distribution</CardTitle>
                   </CardHeader>
                   <CardContent className="space-y-4">
                     <div className="space-y-3">
                       <div className="flex justify-between items-center">
-                        <span className="text-purple-300">High Risk</span>
+                        <span className="text-purple-700">High Risk</span>
                         <div className="flex items-center gap-2">
-                          <div className="w-24 bg-purple-900/50 rounded-full h-2">
+                          <div className="w-24 bg-purple-50 rounded-full h-2">
                             <div
                               className="bg-red-500 h-2 rounded-full"
                               style={{
@@ -152,9 +152,9 @@ export function ThreatDetection({ results, config }: ThreatDetectionProps) {
                         </div>
                       </div>
                       <div className="flex justify-between items-center">
-                        <span className="text-purple-300">Medium Risk</span>
+                        <span className="text-purple-700">Medium Risk</span>
                         <div className="flex items-center gap-2">
-                          <div className="w-24 bg-purple-900/50 rounded-full h-2">
+                          <div className="w-24 bg-purple-50 rounded-full h-2">
                             <div
                               className="bg-yellow-500 h-2 rounded-full"
                               style={{
@@ -166,9 +166,9 @@ export function ThreatDetection({ results, config }: ThreatDetectionProps) {
                         </div>
                       </div>
                       <div className="flex justify-between items-center">
-                        <span className="text-purple-300">Low Risk</span>
+                        <span className="text-purple-700">Low Risk</span>
                         <div className="flex items-center gap-2">
-                          <div className="w-24 bg-purple-900/50 rounded-full h-2">
+                          <div className="w-24 bg-purple-50 rounded-full h-2">
                             <div
                               className="bg-green-500 h-2 rounded-full"
                               style={{
@@ -185,7 +185,7 @@ export function ThreatDetection({ results, config }: ThreatDetectionProps) {
                   </CardContent>
                 </Card>
 
-                <Card className="bg-purple-800/30 border-purple-600">
+                <Card className="bg-purple-50 border-purple-300">
                   <CardHeader>
                     <CardTitle className="text-white text-lg">Security Score</CardTitle>
                   </CardHeader>
@@ -194,10 +194,10 @@ export function ThreatDetection({ results, config }: ThreatDetectionProps) {
                       <div className="text-4xl font-bold text-white mb-2">
                         {(100 - threatAnalysis.threatPercentage).toFixed(0)}%
                       </div>
-                      <p className="text-purple-300">Overall Security Score</p>
+                      <p className="text-purple-700">Overall Security Score</p>
                     </div>
-                    <Progress value={100 - threatAnalysis.threatPercentage} className="bg-purple-900" />
-                    <div className="text-center text-sm text-purple-400">
+                    <Progress value={100 - threatAnalysis.threatPercentage} className="bg-purple-200" />
+                    <div className="text-center text-sm text-purple-600">
                       {threatAnalysis.threatPercentage < 10
                         ? "Excellent"
                         : threatAnalysis.threatPercentage < 25
@@ -213,7 +213,7 @@ export function ThreatDetection({ results, config }: ThreatDetectionProps) {
             </TabsContent>
 
             <TabsContent value="threats" className="space-y-4">
-              <Card className="bg-purple-800/30 border-purple-600">
+              <Card className="bg-purple-50 border-purple-300">
                 <CardHeader>
                   <CardTitle className="text-white text-lg">Detected Threats</CardTitle>
                 </CardHeader>
@@ -223,13 +223,13 @@ export function ThreatDetection({ results, config }: ThreatDetectionProps) {
                       threatAnalysis.suspiciousFiles.map((file, index) => (
                         <div
                           key={index}
-                          className="flex items-center justify-between p-3 bg-purple-900/30 rounded border border-purple-700"
+                          className="flex items-center justify-between p-3 bg-purple-50 rounded border border-purple-300"
                         >
                           <div className="flex items-center gap-3">
                             <AlertTriangle className="w-5 h-5 text-red-400" />
                             <div>
                               <p className="text-white font-medium">{file.filename}</p>
-                              <p className="text-purple-400 text-sm">
+                              <p className="text-purple-600 text-sm">
                                 Malware Score: {file.security?.malware_score?.toFixed(2)}
                               </p>
                             </div>
@@ -243,7 +243,7 @@ export function ThreatDetection({ results, config }: ThreatDetectionProps) {
                       <div className="text-center py-8">
                         <Shield className="w-12 h-12 text-green-400 mx-auto mb-4" />
                         <h3 className="text-lg font-semibold text-white mb-2">No Threats Detected</h3>
-                        <p className="text-purple-300">All scanned files appear to be safe</p>
+                        <p className="text-purple-700">All scanned files appear to be safe</p>
                       </div>
                     )}
                   </div>
@@ -252,7 +252,7 @@ export function ThreatDetection({ results, config }: ThreatDetectionProps) {
             </TabsContent>
 
             <TabsContent value="anomalies" className="space-y-4">
-              <Card className="bg-purple-800/30 border-purple-600">
+              <Card className="bg-purple-50 border-purple-300">
                 <CardHeader>
                   <CardTitle className="text-white text-lg">File Anomalies</CardTitle>
                 </CardHeader>
@@ -262,13 +262,13 @@ export function ThreatDetection({ results, config }: ThreatDetectionProps) {
                       threatAnalysis.anomalies.map((anomaly, index) => (
                         <div
                           key={index}
-                          className="flex items-center justify-between p-3 bg-purple-900/30 rounded border border-purple-700"
+                          className="flex items-center justify-between p-3 bg-purple-50 rounded border border-purple-300"
                         >
                           <div className="flex items-center gap-3">
                             <Eye className="w-5 h-5 text-yellow-400" />
                             <div>
                               <p className="text-white font-medium">{anomaly.filename}</p>
-                              <p className="text-purple-400 text-sm">{anomaly.anomaly}</p>
+                              <p className="text-purple-600 text-sm">{anomaly.anomaly}</p>
                             </div>
                           </div>
                           <Badge className={getThreatColor(anomaly.threat_level)}>{anomaly.threat_level}</Badge>
@@ -278,7 +278,7 @@ export function ThreatDetection({ results, config }: ThreatDetectionProps) {
                       <div className="text-center py-8">
                         <Eye className="w-12 h-12 text-green-400 mx-auto mb-4" />
                         <h3 className="text-lg font-semibold text-white mb-2">No Anomalies Detected</h3>
-                        <p className="text-purple-300">All files conform to expected patterns</p>
+                        <p className="text-purple-700">All files conform to expected patterns</p>
                       </div>
                     )}
                   </div>
@@ -288,7 +288,7 @@ export function ThreatDetection({ results, config }: ThreatDetectionProps) {
 
             <TabsContent value="prevention" className="space-y-4">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <Card className="bg-purple-800/30 border-purple-600">
+                <Card className="bg-purple-50 border-purple-300">
                   <CardHeader>
                     <CardTitle className="text-white text-lg flex items-center gap-2">
                       <Lock className="w-5 h-5" />
@@ -296,24 +296,24 @@ export function ThreatDetection({ results, config }: ThreatDetectionProps) {
                     </CardTitle>
                   </CardHeader>
                   <CardContent className="space-y-3">
-                    <div className="p-3 bg-purple-900/30 rounded border border-purple-700">
+                    <div className="p-3 bg-purple-50 rounded border border-purple-300">
                       <h4 className="text-white font-medium mb-1">Enable Real-time Scanning</h4>
-                      <p className="text-purple-300 text-sm">Monitor files as they are accessed or modified</p>
+                      <p className="text-purple-700 text-sm">Monitor files as they are accessed or modified</p>
                     </div>
-                    <div className="p-3 bg-purple-900/30 rounded border border-purple-700">
+                    <div className="p-3 bg-purple-50 rounded border border-purple-300">
                       <h4 className="text-white font-medium mb-1">Update Engine Signatures</h4>
-                      <p className="text-purple-300 text-sm">
+                      <p className="text-purple-700 text-sm">
                         Keep detection engines updated with latest threat signatures
                       </p>
                     </div>
-                    <div className="p-3 bg-purple-900/30 rounded border border-purple-700">
+                    <div className="p-3 bg-purple-50 rounded border border-purple-300">
                       <h4 className="text-white font-medium mb-1">Quarantine Suspicious Files</h4>
-                      <p className="text-purple-300 text-sm">Automatically isolate files with high threat scores</p>
+                      <p className="text-purple-700 text-sm">Automatically isolate files with high threat scores</p>
                     </div>
                   </CardContent>
                 </Card>
 
-                <Card className="bg-purple-800/30 border-purple-600">
+                <Card className="bg-purple-50 border-purple-300">
                   <CardHeader>
                     <CardTitle className="text-white text-lg flex items-center gap-2">
                       <Zap className="w-5 h-5" />
@@ -330,7 +330,7 @@ export function ThreatDetection({ results, config }: ThreatDetectionProps) {
                     <button className="w-full p-3 bg-blue-900/30 border border-blue-600 rounded text-blue-300 hover:bg-blue-900/50 transition-colors">
                       Generate Security Report
                     </button>
-                    <button className="w-full p-3 bg-purple-900/30 border border-purple-600 rounded text-purple-300 hover:bg-purple-900/50 transition-colors">
+                    <button className="w-full p-3 bg-purple-50 border border-purple-300 rounded text-purple-700 hover:bg-purple-50 transition-colors">
                       Update Threat Database
                     </button>
                   </CardContent>


### PR DESCRIPTION
## Summary
- switch overall layout background gradient to white
- lighten card and text colors across all components
- adjust hover and border colors to match the lighter palette

## Testing
- `pnpm install`
- `npm run lint` *(fails: requires interactive setup)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68654c2d9eb08331b7283787d9033709