### PR TITLE
Improve watch CLI and extend XML detection

### DIFF
--- a/probium/cli.py
+++ b/probium/cli.py
@@ -60,6 +60,9 @@ def cmd_watch(ns: argparse.Namespace) -> None:
 
     print(f"Watching {ns.root}... Press Ctrl+C to stop", file=sys.stderr)
     from .watch import watch
+    if not ns.root.exists():
+        print(f"Path {ns.root} does not exist", file=sys.stderr)
+        return
     try:
         wc = watch(
             ns.root,
@@ -67,6 +70,7 @@ def cmd_watch(ns: argparse.Namespace) -> None:
             recursive=ns.recursive,
             only=ns.only,
             extensions=ns.ext,
+            interval=ns.interval,
         )
     except RuntimeError as exc:
         print(exc, file=sys.stderr)
@@ -105,6 +109,12 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Do not watch subdirectories",
     )
     p_watch.set_defaults(recursive=True)
+    p_watch.add_argument(
+        "--interval",
+        type=float,
+        default=1.0,
+        help="Polling interval when watchdog is unavailable",
+    )
     _add_common_options(p_watch)
     p_watch.set_defaults(func=cmd_watch)
     return p

--- a/probium/engines/xml.py
+++ b/probium/engines/xml.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
+import re
+import mimetypes
+import logging
+import xml.etree.ElementTree as ET
+
 from ..models import Candidate, Result
 from ..scoring import score_magic, score_tokens
 from .base import EngineBase
 from ..registry import register
-import logging
-import mimetypes
 from ..libmagic import load_magic
 
 logger = logging.getLogger(__name__)
@@ -15,9 +18,20 @@ _magic = load_magic()
 class XMLEngine(EngineBase):
     name = "xml"
     cost = 0.05
-    _MAGIC = [b'\xEF\xBB\xBF', b'\xFF\xFE', b'\xFE\xFF', b"<?xml"]
+    _MAGIC = [b"\xEF\xBB\xBF", b"\xFF\xFE", b"\xFE\xFF", b"<?xml"]
+    _TOKEN_RE = re.compile(r"[<>]")
+
+    def _make_result(self, conf: float, breakdown: dict[str, float]) -> Result:
+        cand = Candidate(
+            media_type="application/xml",
+            extension="xml",
+            confidence=conf,
+            breakdown=breakdown,
+        )
+        return Result(candidates=[cand])
 
     def sniff(self, payload: bytes) -> Result:
+        # Layer 1: libmagic
         if _magic is not None:
             try:
                 mime = _magic.from_buffer(payload)
@@ -30,37 +44,97 @@ class XMLEngine(EngineBase):
                         media_type=mime,
                         extension=ext,
                         confidence=score_tokens(1.0),
-                        breakdown={"token_ratio": 1.0},
+                        breakdown={"libmagic": True},
                     )
                     return Result(candidates=[cand])
 
-        window = payload[:64]
-        cand = []
+        try:
+            text = payload.decode("utf-8", errors="ignore")
+        except Exception:
+            return Result(candidates=[])
 
-        for magic in self._MAGIC:
-            idx = window.find(magic)
-            if idx != -1:
-                conf = score_magic(len(magic))
-                if idx != 0:
-                    conf *= 0.9
-                cand.append(
+        window = text[:256]
+        candidates: list[Candidate] = []
+
+        # Layer 2: BOM detection
+        for magic in self._MAGIC[:3]:
+            if payload.startswith(magic):
+                candidates.append(
                     Candidate(
                         media_type="application/xml",
                         extension="xml",
-                        confidence=conf,
-                        breakdown={"magic_len": float(len(magic)), "offset": float(idx)},
+                        confidence=score_magic(len(magic)),
+                        breakdown={"bom": float(len(magic))},
                     )
                 )
                 break
 
-        if not cand and window.lstrip().startswith(b"<") and b">" in window:
-            cand.append(
+        # Layer 3: XML declaration
+        if window.lstrip().startswith("<?xml"):
+            candidates.append(
                 Candidate(
                     media_type="application/xml",
                     extension="xml",
-                    confidence=score_tokens(0.05),
-                    breakdown={"token_ratio": 0.05},
+                    confidence=score_magic(5),
+                    breakdown={"xml_decl": 1.0},
                 )
             )
 
-        return Result(candidates=cand)
+        # Layer 4: attempt parsing
+        try:
+            ET.fromstring(text)
+            candidates.append(
+                Candidate(
+                    media_type="application/xml",
+                    extension="xml",
+                    confidence=score_tokens(1.0),
+                    breakdown={"parsed": 1.0},
+                )
+            )
+        except Exception:
+            pass
+
+        # Layer 5: root tag detection
+        stripped = window.lstrip()
+        if stripped.startswith("<") and ">" in stripped:
+            tag = stripped[1:stripped.find(">")].split()[0].strip("/?")
+            if tag:
+                candidates.append(
+                    Candidate(
+                        media_type="application/xml",
+                        extension="xml",
+                        confidence=score_tokens(0.2),
+                        breakdown={"root_tag": 1.0},
+                    )
+                )
+
+        # Layer 6: balanced tags heuristic
+        open_tags = len(re.findall(r"<[^/!?][^>]*>", window))
+        close_tags = len(re.findall(r"</[^>]+>", window))
+        if open_tags and abs(open_tags - close_tags) <= 2:
+            candidates.append(
+                Candidate(
+                    media_type="application/xml",
+                    extension="xml",
+                    confidence=score_tokens(0.15),
+                    breakdown={"balanced": 1.0},
+                )
+            )
+
+        # Layer 7: token ratio
+        token_ratio = len(self._TOKEN_RE.findall(window)) / max(len(window), 1)
+        if token_ratio > 0.05:
+            candidates.append(
+                Candidate(
+                    media_type="application/xml",
+                    extension="xml",
+                    confidence=score_tokens(min(token_ratio, 0.7)),
+                    breakdown={"token_ratio": round(token_ratio, 3)},
+                )
+            )
+
+        if not candidates:
+            return Result(candidates=[])
+
+        best = max(candidates, key=lambda c: c.confidence)
+        return Result(candidates=[best])

--- a/probium/watch.py
+++ b/probium/watch.py
@@ -159,6 +159,7 @@ class PollingWatchContainer:
         ):
             if p.is_file():
                 self.handler._seen.add(p)
+        self._scan()
         self._thread.start()
 
     def stop(self) -> None:


### PR DESCRIPTION
## Summary
- add `--interval` and path validation to `probium watch`
- start polling watch with an initial scan
- implement multi-layered XML detection using libmagic, BOMs, parsing and token heuristics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68657d8590b083319bd7947ad89b3c54