### PR TITLE
Improve engine short-circuiting

### DIFF
--- a/probium/core.py
+++ b/probium/core.py
@@ -110,6 +110,14 @@ def _detect_file(
     if engine != "auto":
         return get_instance(engine)(payload)
 
+    if only is not None:
+        only_list = list(only)
+        if len(only_list) == 1:
+            res = get_instance(only_list[0])(payload)
+            if cache and isinstance(source, (str, Path)):
+                cache_put(Path(source), res)
+            return res
+
     magic_best: Result | None = None
 
     if only is not None:

--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,7 @@ meta = detect(
     only=["hash", "pdf"],   # run just these engines
     cap_bytes=1_000_000     # read at most 1 MB
 )
+# Using a single engine short-circuits the search for near O(1) performance
 
 ### 4) Stream-scan an entire folder
 for path, m in scan_dir("docs", pattern="**/*.pdf", workers=4):


### PR DESCRIPTION
## Summary
- short-circuit detection when a single `--only` engine is provided
- document `--only` short-circuiting in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68657e13b124833193ee71cb4b58ada7