### PR TITLE
Add local Probium integration

### DIFF
--- a/app/api/v1/engines/route.ts
+++ b/app/api/v1/engines/route.ts
@@ -1,5 +1,13 @@
-import { proxy } from '@/app/api/_proxy'
+import { NextResponse } from 'next/server'
+import { localGetEngines } from '@/lib/local'
+
+export const runtime = 'nodejs'
 
 export async function GET() {
-  return proxy('/api/v1/engines')
+  try {
+    const data = await localGetEngines()
+    return NextResponse.json(data)
+  } catch (err: any) {
+    return NextResponse.json({ error: String(err) }, { status: 500 })
+  }
 }

--- a/app/api/v1/engines/status/route.ts
+++ b/app/api/v1/engines/status/route.ts
@@ -1,5 +1,13 @@
-import { proxy } from '@/app/api/_proxy'
+import { NextResponse } from 'next/server'
+import { localGetEngines } from '@/lib/local'
+
+export const runtime = 'nodejs'
 
 export async function GET() {
-  return proxy('/api/v1/engines/status')
+  try {
+    const { engines } = await localGetEngines()
+    return NextResponse.json({ engines })
+  } catch (err: any) {
+    return NextResponse.json({ error: String(err) }, { status: 500 })
+  }
 }

--- a/app/api/v1/scan/[scan_id]/status/route.ts
+++ b/app/api/v1/scan/[scan_id]/status/route.ts
@@ -1,5 +1,16 @@
-import { proxy } from '@/app/api/_proxy'
+import { NextResponse } from 'next/server'
+import { localGetScanStatus } from '@/lib/local'
+
+export const runtime = 'nodejs'
 
 export async function GET(request: Request, { params }: { params: { scan_id: string } }) {
-  return proxy(`/api/v1/scan/${params.scan_id}/status`)
+  try {
+    const data = await localGetScanStatus(params.scan_id)
+    if (!data) {
+      return NextResponse.json({ error: 'not found' }, { status: 404 })
+    }
+    return NextResponse.json({ scan: data })
+  } catch (err: any) {
+    return NextResponse.json({ error: String(err) }, { status: 500 })
+  }
 }

--- a/app/api/v1/scan/file/route.ts
+++ b/app/api/v1/scan/file/route.ts
@@ -1,7 +1,18 @@
-import { NextRequest } from 'next/server'
-import { proxy } from '@/app/api/_proxy'
+import { NextRequest, NextResponse } from 'next/server'
+import { localScanFile } from '@/lib/local'
+
+export const runtime = 'nodejs'
 
 export async function POST(req: NextRequest) {
-  const data = await req.formData()
-  return proxy('/api/v1/scan/file', { method: 'POST', body: data })
+  const form = await req.formData()
+  const file = form.get('file')
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: 'missing file' }, { status: 400 })
+  }
+  try {
+    const result = await localScanFile(file)
+    return NextResponse.json({ result })
+  } catch (err: any) {
+    return NextResponse.json({ error: String(err) }, { status: 500 })
+  }
 }

--- a/app/api/v1/scan/history/route.ts
+++ b/app/api/v1/scan/history/route.ts
@@ -1,7 +1,15 @@
-import { NextRequest } from 'next/server'
-import { proxy } from '@/app/api/_proxy'
+import { NextRequest, NextResponse } from 'next/server'
+import { localGetScanHistory } from '@/lib/local'
+
+export const runtime = 'nodejs'
 
 export async function GET(req: NextRequest) {
   const url = new URL(req.url)
-  return proxy(`/api/v1/scan/history${url.search}`)
+  const limit = Number(url.searchParams.get('limit') || '100')
+  try {
+    const data = await localGetScanHistory(limit)
+    return NextResponse.json(data)
+  } catch (err: any) {
+    return NextResponse.json({ error: String(err) }, { status: 500 })
+  }
 }

--- a/app/api/v1/system/metrics/route.ts
+++ b/app/api/v1/system/metrics/route.ts
@@ -1,5 +1,13 @@
-import { proxy } from '@/app/api/_proxy'
+import { NextResponse } from 'next/server'
+import { localGetSystemMetrics } from '@/lib/local'
+
+export const runtime = 'nodejs'
 
 export async function GET() {
-  return proxy('/api/v1/system/metrics')
+  try {
+    const metrics = await localGetSystemMetrics()
+    return NextResponse.json({ metrics })
+  } catch (err: any) {
+    return NextResponse.json({ error: String(err) }, { status: 500 })
+  }
 }

--- a/lib/local.ts
+++ b/lib/local.ts
@@ -1,0 +1,107 @@
+import { spawn } from 'child_process'
+import { writeFile, unlink, readFile, access, constants } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import type { ScanResult, Engine, SystemMetrics } from './api'
+
+async function runPython(args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('python', args)
+    let out = ''
+    let err = ''
+    proc.stdout.on('data', (d) => { out += d })
+    proc.stderr.on('data', (d) => { err += d })
+    proc.on('close', (code) => {
+      if (code === 0) resolve(out.trim())
+      else reject(new Error(err || `Python exited with code ${code}`))
+    })
+  })
+}
+
+const HISTORY_FILE = join(process.cwd(), 'local_scan_history.json')
+
+async function appendHistory(res: ScanResult) {
+  let data: ScanResult[] = []
+  try {
+    await access(HISTORY_FILE, constants.F_OK)
+    const txt = await readFile(HISTORY_FILE, 'utf8')
+    data = JSON.parse(txt)
+  } catch {
+    data = []
+  }
+  data.unshift(res)
+  await writeFile(HISTORY_FILE, JSON.stringify(data, null, 2))
+}
+
+export async function localScanFile(file: File): Promise<ScanResult> {
+  const buffer = Buffer.from(await file.arrayBuffer())
+  const tmpPath = join(tmpdir(), `${Date.now()}_${file.name}`)
+  await writeFile(tmpPath, buffer)
+  try {
+    const out = await runPython(['-m', 'probium.cli', 'detect', tmpPath, '--raw'])
+    const parsed = JSON.parse(out)
+    const cand = parsed.candidates?.[0] ?? {}
+    const result: ScanResult = {
+      id: String(Date.now()),
+      filename: file.name,
+      size: file.size,
+      detected_type: cand.media_type || '',
+      mime_type: cand.media_type || '',
+      confidence: cand.confidence || 0,
+      extension: cand.extension ?? null,
+      engines_used: [parsed.engine || ''],
+      scan_time: `${parsed.elapsed_ms}ms`,
+      timestamp: new Date().toISOString(),
+      probium_version: parsed.probium_version || '',
+    }
+    await appendHistory(result)
+    return result
+  } finally {
+    await unlink(tmpPath).catch(() => {})
+  }
+}
+
+export async function localGetEngines(): Promise<{ engines: Engine[]; total: number }> {
+  const out = await runPython(['-c', 'import json, probium; print(json.dumps(probium.list_engines()))'])
+  const names: string[] = JSON.parse(out)
+  return { engines: names.map((name) => ({ name, cost: 1, status: 'available', version: '' })), total: names.length }
+}
+
+export async function localGetScanHistory(limit = 100): Promise<{ scans: ScanResult[]; total: number }> {
+  try {
+    const txt = await readFile(HISTORY_FILE, 'utf8')
+    const scans: ScanResult[] = JSON.parse(txt)
+    return { scans: scans.slice(0, limit), total: scans.length }
+  } catch {
+    return { scans: [], total: 0 }
+  }
+}
+
+export async function localGetSystemMetrics(): Promise<SystemMetrics> {
+  const os = await import('os')
+  const total = os.totalmem()
+  const free = os.freemem()
+  return {
+    cpu_usage: os.loadavg()[0],
+    memory_usage: (total - free) / total,
+    memory_total: total,
+    memory_used: total - free,
+    disk_usage: 0,
+    disk_total: 0,
+    disk_used: 0,
+    active_threads: os.cpus().length,
+    total_scans: 0,
+    engine_stats: {},
+    timestamp: new Date().toISOString(),
+  }
+}
+
+export async function localGetScanStatus(id: string): Promise<ScanResult | null> {
+  try {
+    const txt = await readFile(HISTORY_FILE, 'utf8')
+    const scans: ScanResult[] = JSON.parse(txt)
+    return scans.find((s) => s.id === id) || null
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary
- run Probium library directly from Next.js API routes
- add helpers for executing Python functions and storing history

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: unable to resolve dependency tree)*

------
https://chatgpt.com/codex/tasks/task_e_68657e74d5b88331850482f937ad65ae