### PR TITLE
Add Google Magika option

### DIFF
--- a/probium/__init__.py
+++ b/probium/__init__.py
@@ -1,6 +1,7 @@
 from importlib.metadata import entry_points, version
 from typing import TYPE_CHECKING
 from .core import detect, scan_dir, list_engines
+from .google_magika import detect_magika
 from .magic_service import detect_magic
 from .trid_multi import detect_with_trid
 from .exceptions import EngineFailure, FastbackError, UnsupportedType
@@ -20,6 +21,7 @@ __all__ = [
     "EngineFailure",
     "detect_with_trid",
     "detect_magic",
+    "detect_magika",
     "watch",
 
 ]

--- a/probium/cli.py
+++ b/probium/cli.py
@@ -4,6 +4,7 @@ import json
 import sys
 from pathlib import Path
 from .core import detect, _detect_file, scan_dir
+from .google_magika import detect_magika
 from .trid_multi import detect_with_trid
 import time
 
@@ -12,16 +13,21 @@ def cmd_detect(ns: argparse.Namespace) -> None:
     target = ns.path
     if target.is_dir():
         results: list[dict] = []
-        for path, res in scan_dir(
-            target,
+        scan_kwargs = dict(
             pattern=ns.pattern,
             workers=ns.workers,
             cap_bytes=ns.capbytes,
-            only=ns.only,
             extensions=ns.ext,
             ignore=ns.ignore,
-            no_cap=ns.nocap
-        ):
+            no_cap=ns.nocap,
+        )
+        if ns.magika:
+            scan_kwargs["engine"] = "magika"
+            scan_kwargs.pop("cap_bytes", None)
+        else:
+            scan_kwargs["only"] = ns.only
+
+        for path, res in scan_dir(target, **scan_kwargs):
             entry = {"path": str(path), **res.model_dump()}
             if ns.trid:
                 trid_res = _detect_file(path, engine="trid", cap_bytes=None)
@@ -33,18 +39,21 @@ def cmd_detect(ns: argparse.Namespace) -> None:
             res_map = detect_with_trid(
                 target,
                 cap_bytes=ns.capbytes,
-                only=ns.only,
+                only=None if ns.magika else ns.only,
                 extensions=ns.ext,
             )
             out = {k: v.model_dump() for k, v in res_map.items()}
         else:
-            res = _detect_file(
-                target,
-                cap_bytes=ns.capbytes,
-                only=ns.only,
-                extensions=ns.ext,
-                no_cap=ns.nocap
-            )
+            if ns.magika:
+                res = detect_magika(target, cap_bytes=None)
+            else:
+                res = _detect_file(
+                    target,
+                    cap_bytes=ns.capbytes,
+                    only=ns.only,
+                    extensions=ns.ext,
+                    no_cap=ns.nocap
+                )
             out = res.model_dump()
         json.dump(out, sys.stdout, indent=None if ns.raw else 2)
     sys.stdout.write("\n")
@@ -68,9 +77,10 @@ def cmd_watch(ns: argparse.Namespace) -> None:
             ns.root,
             _handle,
             recursive=ns.recursive,
-            only=ns.only,
+            only=None if ns.magika else ns.only,
             extensions=ns.ext,
             interval=ns.interval,
+            magika=ns.magika,
         )
     except RuntimeError as exc:
         print(exc, file=sys.stderr)
@@ -136,6 +146,11 @@ def _add_common_options(ap: argparse.ArgumentParser) -> None:
     ap.add_argument("--trid", action="store_true", help="Include TRiD engine")
     ap.add_argument("--capbytes", type=int, default=4096, help="Max number of bytes to scan (default = 4096)")
     ap.add_argument("--nocap", action="store_true", help="Removes limit on how many bytes to scan")
+    ap.add_argument(
+        "--magika",
+        action="store_true",
+        help="Use Google Magika exclusively for detection",
+    )
 
 def main() -> None:
     ns = _build_parser().parse_args()

--- a/probium/engines/magika.py
+++ b/probium/engines/magika.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+from ..models import Candidate, Result
+from .base import EngineBase
+from ..registry import register
+
+try:
+    from magika import Magika
+except Exception as exc:  # pragma: no cover - optional dependency
+    Magika = None  # type: ignore
+
+
+@register
+class MagikaEngine(EngineBase):
+    """Engine backed by the Google Magika library."""
+
+    name = "magika"
+    cost = 0.05
+    opt_in_only = True
+
+    def __init__(self) -> None:
+        super().__init__()
+        if Magika is None:
+            raise RuntimeError("Google Magika library is required for this engine")
+        self._magika = Magika()
+
+    def sniff(self, payload: bytes) -> Result:
+        res = self._magika.identify_bytes(payload)
+        info = res.prediction.output
+        cand = Candidate(
+            media_type=info.mime_type,
+            extension=info.extensions[0] if info.extensions else None,
+            confidence=float(res.prediction.score),
+        )
+        return Result(candidates=[cand])

--- a/probium/google_magika.py
+++ b/probium/google_magika.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+from pathlib import Path
+from typing import Any
+
+from .core import _detect_file
+from .models import Result
+
+
+def detect_magika(source: str | Path | bytes, *, cap_bytes: int | None = None) -> Result:
+    """Detect file type using only the Google Magika engine."""
+    return _detect_file(source, engine="magika", cap_bytes=cap_bytes)

--- a/probium/registry.py
+++ b/probium/registry.py
@@ -45,5 +45,6 @@ def list_engines() -> list[str]:
         for name, cls in sorted(
             _engines.items(), key=lambda kv: getattr(kv[1], "cost", 1.0)
         )
+        if not getattr(cls, "opt_in_only", False)
     ]
 all_engines = lambda: MappingProxyType(_engines)

--- a/probium/watch.py
+++ b/probium/watch.py
@@ -35,6 +35,7 @@ class _FilterHandler(FileSystemEventHandler):
         recursive: bool = True,
         only: Iterable[str] | None = None,
         extensions: Iterable[str] | None = None,
+        magika: bool = False,
     ) -> None:
         self.callback = callback
         self.recursive = recursive
@@ -43,6 +44,7 @@ class _FilterHandler(FileSystemEventHandler):
             {e.lower().lstrip(".") for e in extensions} if extensions else None
         )
         self._seen: set[Path] = set()
+        self.magika = magika
 
     def on_created(self, event: FileSystemEvent) -> None:
         """Handle created paths."""
@@ -67,7 +69,10 @@ class _FilterHandler(FileSystemEventHandler):
             return
         if self.extensions and path.suffix.lower().lstrip(".") not in self.extensions:
             return
-        res = detect(path, only=self.only, extensions=self.extensions, cap_bytes=None)
+        if self.magika:
+            res = detect(path, engine="magika", cap_bytes=None)
+        else:
+            res = detect(path, only=self.only, extensions=self.extensions, cap_bytes=None)
         try:
             self.callback(path, res)
         except Exception:
@@ -85,6 +90,7 @@ class WatchContainer:
         recursive: bool = True,
         only: Iterable[str] | None = None,
         extensions: Iterable[str] | None = None,
+        magika: bool = False,
     ) -> None:
         self.root = Path(root)
         self.callback = callback
@@ -94,6 +100,7 @@ class WatchContainer:
             recursive=recursive,
             only=only,
             extensions=extensions,
+            magika=magika,
         )
         self.observer = Observer()
 
@@ -125,6 +132,7 @@ class PollingWatchContainer:
         only: Iterable[str] | None = None,
         extensions: Iterable[str] | None = None,
         interval: float = 1.0,
+        magika: bool = False,
     ) -> None:
         self.root = Path(root)
         self.callback = callback
@@ -135,6 +143,7 @@ class PollingWatchContainer:
             recursive=recursive,
             only=only,
             extensions=extensions,
+            magika=magika,
         )
         self._stop = threading.Event()
         self._thread = threading.Thread(target=self._run, daemon=True)
@@ -171,6 +180,7 @@ def watch(
     only: Iterable[str] | None = None,
     extensions: Iterable[str] | None = None,
     interval: float = 1.0,
+    magika: bool = False,
 ) -> WatchContainer:
     """Start watching ``root`` and invoke ``callback`` for new files.
 
@@ -190,10 +200,16 @@ def watch(
             only=only,
             extensions=extensions,
             interval=interval,
+            magika=magika,
         )
     else:
         container = WatchContainer(
-            root, callback, recursive=recursive, only=only, extensions=extensions
+            root,
+            callback,
+            recursive=recursive,
+            only=only,
+            extensions=extensions,
+            magika=magika,
         )
     container.start()
     return container

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,9 @@ pip install watchdog
 ### To scan a file or folder
 "probium detect path/to/file_or_folder"
 
+### Use Google Magika instead of built-in engines
+"probium detect path/to/file --magika"
+
 
 ### To monitor a folder for new files
 "probium watch path/to/folder"
@@ -50,6 +53,7 @@ pip install watchdog
 ### 1) Import
 
 from probium import detect, detect_magic, scan_dir
+from probium import detect_magika
 
 
 ### 2) Peek at one file
@@ -57,6 +61,8 @@ meta = detect("sample.pdf")            # returns a rich Pydantic model
 print("SHA-256 🔮", meta.hash.sha256)  # 🍇 easy attribute access
 
 meta_fast = detect_magic(b"%PDF-1.4\n...")  # use magic-number lookup
+
+meta_magika = detect_magika("sample.pdf")  # use Google Magika
 
 ### 3) Fine-tune if you like
 meta = detect(

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -6,7 +6,7 @@ import time
 import asyncio
 import pytest
 
-from probium import detect, detect_async
+from probium import detect, detect_async, detect_magika
 
 # Directory containing sample files for tests
 SAMPLES_DIR = Path(__file__).parent / "samples"
@@ -136,3 +136,11 @@ def test_watch_polling(monkeypatch, tmp_path):
         wc.stop()
 
     assert paths and paths[0] == f
+
+
+def test_detect_magika():
+    path = SAMPLES_DIR / "sample.csv"
+    res = detect_magika(path)
+    cand = res.candidates[0]
+    assert cand.media_type == "text/csv"
+    assert cand.extension == "csv"


### PR DESCRIPTION
## Summary
- integrate Google Magika as an optional engine
- add `--magika` flag to CLI commands and support in watch utility
- export `detect_magika()` from library
- prevent Magika engine from running unless explicitly requested
- document new feature and extend tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68658f9984c88331a2899873efa2c7fc