### PR TITLE
Add global Magika option

### DIFF
--- a/probium/__init__.py
+++ b/probium/__init__.py
@@ -1,6 +1,7 @@
 from importlib.metadata import entry_points, version
 from typing import TYPE_CHECKING
 from .core import detect, scan_dir, list_engines
+from .google_magika import detect_magika, require_magika, magika_env_only
 from .magic_service import detect_magic
 from .trid_multi import detect_with_trid
 from .exceptions import EngineFailure, FastbackError, UnsupportedType
@@ -20,6 +21,9 @@ __all__ = [
     "EngineFailure",
     "detect_with_trid",
     "detect_magic",
+    "detect_magika",
+    "require_magika",
+    "magika_env_only",
     "watch",
 
 ]

--- a/probium/core.py
+++ b/probium/core.py
@@ -11,6 +11,7 @@ from typing import Any, Iterable, Sequence
 DEFAULT_IGNORES = {".git", "venv", ".venv", "__pycache__"}
 from .cache import get as cache_get, put as cache_put
 from .registry import list_engines, get_instance
+from .google_magika import magika_env_only, require_magika
 from .magic_service import MAGIC_SIGNATURES, _MAX_SCAN
 from .scoring import score_magic
 
@@ -78,6 +79,11 @@ def _detect_file(
     cache:
         Whether to store and retrieve results from the cache.
     """
+
+    if magika_env_only() and engine == "auto" and only is None:
+        require_magika()
+        engine = "magika"
+        cap_bytes = None
 
     if cap_bytes is not None and cap_bytes < 0:
         cap_bytes = None

--- a/probium/engines/magika.py
+++ b/probium/engines/magika.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+from ..models import Candidate, Result
+from .base import EngineBase
+from ..registry import register
+
+try:
+    from magika import Magika
+except Exception as exc:  # pragma: no cover - optional dependency
+    Magika = None  # type: ignore
+
+
+@register
+class MagikaEngine(EngineBase):
+    """Engine backed by the Google Magika library."""
+
+    name = "magika"
+    cost = 0.05
+    opt_in_only = True
+
+    def __init__(self) -> None:
+        super().__init__()
+        if Magika is None:
+            raise RuntimeError("Google Magika library is required for this engine")
+        self._magika = Magika()
+
+    def sniff(self, payload: bytes) -> Result:
+        res = self._magika.identify_bytes(payload)
+        info = res.prediction.output
+        cand = Candidate(
+            media_type=info.mime_type,
+            extension=info.extensions[0] if info.extensions else None,
+            confidence=float(res.prediction.score),
+        )
+        return Result(candidates=[cand])

--- a/probium/google_magika.py
+++ b/probium/google_magika.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+from pathlib import Path
+from typing import Any
+import os
+
+from .models import Result
+import importlib
+
+
+def magika_available() -> bool:
+    """Return ``True`` if the optional ``magika`` package can be imported."""
+    try:
+        importlib.import_module("magika")
+    except Exception:
+        return False
+    return True
+
+
+def magika_env_only() -> bool:
+    """Return ``True`` if the environment forces Magika-only detection."""
+    return os.getenv("PROBIUM_MAGIKA_ONLY", "").lower() in {"1", "true", "yes"}
+
+
+def require_magika() -> None:
+    """Raise ``RuntimeError`` if the ``magika`` package is missing."""
+    if not magika_available():
+        raise RuntimeError(
+            "Google Magika library is required. Install with `pip install magika`."
+        )
+
+
+def detect_magika(source: str | Path | bytes, *, cap_bytes: int | None = None) -> Result:
+    """Detect file type using only the Google Magika engine."""
+    require_magika()
+    from .core import _detect_file
+    return _detect_file(source, engine="magika", cap_bytes=cap_bytes)

--- a/probium/registry.py
+++ b/probium/registry.py
@@ -45,5 +45,6 @@ def list_engines() -> list[str]:
         for name, cls in sorted(
             _engines.items(), key=lambda kv: getattr(kv[1], "cost", 1.0)
         )
+        if not getattr(cls, "opt_in_only", False)
     ]
 all_engines = lambda: MappingProxyType(_engines)

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,16 @@ pip install watchdog
 ### To scan a file or folder
 "probium detect path/to/file_or_folder"
 
+### Use Google Magika instead of built-in engines
+"probium detect path/to/file --magika"
+*Requires the optional `magika` package*
+
+### Watch a folder with Google Magika
+"probium watch path/to/folder --magika"
+
+Set ``PROBIUM_MAGIKA_ONLY=1`` in the environment to make Magika the default
+engine for all detection commands.
+
 
 ### To monitor a folder for new files
 "probium watch path/to/folder"
@@ -50,6 +60,11 @@ pip install watchdog
 ### 1) Import
 
 from probium import detect, detect_magic, scan_dir
+from probium import detect_magika  # requires `magika` package
+from probium import magika_env_only  # check if PROBIUM_MAGIKA_ONLY is set
+
+if magika_env_only():
+    print("Magika-only mode active")
 
 
 ### 2) Peek at one file
@@ -57,6 +72,8 @@ meta = detect("sample.pdf")            # returns a rich Pydantic model
 print("SHA-256 🔮", meta.hash.sha256)  # 🍇 easy attribute access
 
 meta_fast = detect_magic(b"%PDF-1.4\n...")  # use magic-number lookup
+
+meta_magika = detect_magika("sample.pdf")  # use Google Magika if installed
 
 ### 3) Fine-tune if you like
 meta = detect(

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -6,7 +6,7 @@ import time
 import asyncio
 import pytest
 
-from probium import detect, detect_async
+from probium import detect, detect_async, detect_magika
 
 # Directory containing sample files for tests
 SAMPLES_DIR = Path(__file__).parent / "samples"
@@ -136,3 +136,22 @@ def test_watch_polling(monkeypatch, tmp_path):
         wc.stop()
 
     assert paths and paths[0] == f
+
+
+def test_detect_magika():
+    pytest.importorskip("magika")
+    path = SAMPLES_DIR / "sample.csv"
+    res = detect_magika(path)
+    cand = res.candidates[0]
+    assert cand.media_type == "text/csv"
+    assert cand.extension == "csv"
+
+
+def test_magika_env(monkeypatch):
+    pytest.importorskip("magika")
+    monkeypatch.setenv("PROBIUM_MAGIKA_ONLY", "1")
+    path = SAMPLES_DIR / "sample.csv"
+    res = detect(path, cap_bytes=None)
+    cand = res.candidates[0]
+    assert cand.media_type == "text/csv"
+    assert res.engine == "magika"


### PR DESCRIPTION
## Summary
- introduce `PROBIUM_MAGIKA_ONLY` envvar to force Magika engine
- expose `require_magika` and `magika_env_only` helpers
- update CLI and detection logic to honour envvar
- document Magika-only mode and add tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68658f9984c88331a2899873efa2c7fc