### PR TITLE
Add colorized CLI output option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,9 @@ pip install watchdog
 
 *Requires the optional `magika` package*
 
+### Colorize path output by file type
+"probium detect path/to/file --color"
+
 
 
 ### To monitor a folder for new files


### PR DESCRIPTION
## Summary
- add CLI option `--color` for colorized paths
- colorize paths in `detect` and `watch` commands based on file extension
- document the new `--color` option in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686684a94f5c833185517997a4ba72db