### PR TITLE
Limit scanned bytes and handle partial zip

### DIFF
--- a/probium/core.py
+++ b/probium/core.py
@@ -130,7 +130,7 @@ def _detect_file(
         "ppt",
         "xls",
     }:
-        cap_bytes = 10000000
+        cap_bytes = min(8192, cap_bytes or 8192)
 
     scan_cap = cap_bytes
     if engine == "auto" and only is None:
@@ -191,7 +191,7 @@ def _detect_file(
         and cap_bytes is not None
         and isinstance(source, (str, Path))
     ):
-        payload = Path(source).read_bytes()
+        payload = Path(source).read_bytes()[:scan_cap]
         for name in engines:
             res = get_instance(name)(payload)
             if res.candidates:

--- a/probium/engines/zip_office.py
+++ b/probium/engines/zip_office.py
@@ -1,7 +1,7 @@
 #made for zip files - recursive scan example engine
 from __future__ import annotations
 from ..scoring import score_magic, score_tokens
-import zipfile, io, re, xml.etree.ElementTree as ET
+import zipfile, io, re, xml.etree.ElementTree as ET, struct, zlib
 from ..models import Candidate, Result
 from .base import EngineBase
 from ..registry import register
@@ -101,6 +101,30 @@ class ZipOfficeEngine(EngineBase):
                         )
                     )
         except Exception:
+            # Fallback for truncated archives: try to parse first entry directly
+            try:
+                sig, ver, flags, method, mtime, mdate, crc, csize, usize, nlen, elen = struct.unpack_from(
+                    "<IHHHHHIIIHH", payload, 0
+                )
+                name = payload[30 : 30 + nlen].decode("utf-8", errors="ignore")
+                data_start = 30 + nlen + elen
+                data = payload[data_start : data_start + csize]
+                if len(data) == csize and name == "mimetype":
+                    content = data if method == 0 else zlib.decompress(data)
+                    mime = content.decode(errors="ignore").strip()
+                    if mime in _SIGS["mimetype"]:
+                        mt, ext = _SIGS["mimetype"][mime]
+                        cand.append(
+                            Candidate(
+                                media_type=mt,
+                                extension=ext,
+                                confidence=score_magic(len(mime)),
+                                breakdown={"partial": 1.0},
+                            )
+                        )
+                        return Result(candidates=cand)
+            except Exception:
+                pass
             cand.append(
                 Candidate(media_type="application/zip", extension="zip", confidence=0.98)
             )


### PR DESCRIPTION
## Summary
- cap scan volume at 8 KiB for certain archive types
- use only the capped amount when rescanning
- parse the first zip entry directly when the file is truncated

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686be011678c8331916525ee1c4ea2eb